### PR TITLE
refactor: generate tools and team lists from data

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -27,7 +27,7 @@
       <header class="navi">
         <nav class="nav" role="navigation" aria-label="Main">
           <ul class="nav-links">
-            <li class="nav-item logo">
+            <li class="nav-item logo" >
               <a href="/">Deven</a>
             </li>
             <li class="nav-item subnav" id="subnav" >
@@ -50,15 +50,11 @@
                 </ul>
                 <button class="close-btn" onclick="closeSubnav()"><span class="visually-hidden">Close Discover menu</span></button>
               </div>
-            </li>
-                <li class="nav-item" >
-                  <a href="/contributors/">Contributors</a>
-                </li>
-              
-                <li class="nav-item" >
-                  <a href="/blog-post/">Blog</a>
-                </li>
-              </ul>
+            </li><li class="nav-item" >
+                <a href="/blog-post/">Blog</a>
+              </li><li class="nav-item" >
+                <a href="/contributors/">Contributors</a>
+              </li></ul>
         </nav>
       </header>
       <main class="tmpl-not-found home">

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -158,105 +158,93 @@
                 </symbol>
             </defs>
         </svg>
-        <ul>
-            <li>
-                <a href='./documentation-skeleton'>
-                    <h3>Documentation Skeleton</h3>
-                    <div aria-hidden="true" class="arrow-circle">
-                        <div class="animated-arrow">
-                            <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
-                            <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+
+        <ul><li>
+                    <a href="/boiler/">
+                        <h3>Boiler</h3>
+                        <div aria-hidden="true" class="arrow-circle">
+                            <div class="animated-arrow">
+                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                            </div>
                         </div>
-                    </div>
-                </a>
-            </li>
-            <li>
-                <a href='./telemetry'>
-                    <h3>Telemetry</h3>
-                    <div aria-hidden="true" class="arrow-circle">
-                        <div class="animated-arrow">
-                            <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
-                            <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                    </a>
+                </li><li>
+                    <a href="/documentation-skeleton/">
+                        <h3>Documentation Skeleton</h3>
+                        <div aria-hidden="true" class="arrow-circle">
+                            <div class="animated-arrow">
+                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                            </div>
                         </div>
-                    </div>
-                </a>
-            </li>
-            <li>
-                <a href='./boiler'>
-                    <h3>BO1LER</h3>
-                    <div aria-hidden="true" class="arrow-circle">
-                        <div class="animated-arrow">
-                            <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
-                            <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                    </a>
+                </li><li>
+                    <a href="/telemetry/">
+                        <h3>Telemetry</h3>
+                        <div aria-hidden="true" class="arrow-circle">
+                            <div class="animated-arrow">
+                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                            </div>
                         </div>
-                    </div>
-                </a>
-            </li>
-        </ul>
+                    </a>
+                </li></ul>
     </div>
 
     <div class="current-team" id='team'>
         <div class="team-title"> 
             <h2 class="november-font">current team</h2>
         </div>
-        <div class="team-members">
-            <div class="team-member">
-                <img src="./assets/images/ola.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">Ola Gasidlo-Brändel</h3>
-                    <p class="member-title">Project Lead</p>
-                </div>
-            </div>
-            <div class="team-member">
-                <img src="./assets/images/simon.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">Simon Novak</h3>
-                    <p class="member-title">Product Owner</p>
-                </div>
-            </div>
-            <div class="team-member">
-                <img src="./assets/images/giordana.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">Giordana Furquim</h3>
-                    <p class="member-title">Technical Product Owner</p>
-                </div>
-            </div>
-            <div class="team-member">
-                <img src="./assets/images/raffaele.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">Raffaele Pizzari</h3>
-                    <p class="member-title">Lead Product Engineer</p>
-                </div>
-            </div>
-            <div class="team-member">
-                <img src="./assets/images/ross.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">Ross DiLiegro</h3>
-                    <p class="member-title">Product Engineer</p>
-                </div>
-            </div>
-            <div class="team-member">
-                <img src="./assets/images/david.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">David Kennedy</h3>
-                    <p class="member-title">Product Engineer</p>
-                </div>
-            </div>
-            <div class="team-member">
-                <img src="./assets/images/kundan.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">Kundan Pawar</h3>
-                    <p class="member-title">Product Engineer</p>
-                </div>
-            </div>
-            <div class="team-member">
-                <img src="./assets/images/ania.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">Ania Bui</h3>
-                    <p class="member-title">Product Designer</p>
-                </div>
-            </div>
-        </div>
+        <div class="team-members"><div class="team-member">
+                    <img src="/assets/images/ola.jpg" alt="" class="member-pic">
+                    <div class="member-info">
+                        <h3 class="member-name">Ola Gasidlo-Brändel</h3>
+                        <p class="member-title">Project Lead</p>
+                    </div>
+                </div><div class="team-member">
+                    <img src="/assets/images/simon.jpg" alt="" class="member-pic">
+                    <div class="member-info">
+                        <h3 class="member-name">Simon Novak</h3>
+                        <p class="member-title">Product Owner</p>
+                    </div>
+                </div><div class="team-member">
+                    <img src="/assets/images/giordana.jpg" alt="" class="member-pic">
+                    <div class="member-info">
+                        <h3 class="member-name">Giordana Furquim</h3>
+                        <p class="member-title">Technical Product Owner</p>
+                    </div>
+                </div><div class="team-member">
+                    <img src="/assets/images/raffaele.jpg" alt="" class="member-pic">
+                    <div class="member-info">
+                        <h3 class="member-name">Raffaele Pizzari</h3>
+                        <p class="member-title">Lead Product Engineer</p>
+                    </div>
+                </div><div class="team-member">
+                    <img src="/assets/images/ross.jpg" alt="" class="member-pic">
+                    <div class="member-info">
+                        <h3 class="member-name">Ross DiLiegro</h3>
+                        <p class="member-title">Product Engineer</p>
+                    </div>
+                </div><div class="team-member">
+                    <img src="/assets/images/david.jpg" alt="" class="member-pic">
+                    <div class="member-info">
+                        <h3 class="member-name">David Kennedy</h3>
+                        <p class="member-title">Product Engineer</p>
+                    </div>
+                </div><div class="team-member">
+                    <img src="/assets/images/kundan.jpg" alt="" class="member-pic">
+                    <div class="member-info">
+                        <h3 class="member-name">Kundan Pawar</h3>
+                        <p class="member-title">Product Engineer</p>
+                    </div>
+                </div><div class="team-member">
+                    <img src="/assets/images/ania.jpg" alt="" class="member-pic">
+                    <div class="member-info">
+                        <h3 class="member-name">Ania Bui</h3>
+                        <p class="member-title">Product Designer</p>
+                    </div>
+                </div></div>
         <a href='./contributors' class="cta-btn">
             <span>Contributors <span aria-hidden="true">→</span></span>
         </a>

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -160,16 +160,6 @@
         </svg>
 
         <ul><li>
-                    <a href="/boiler/">
-                        <h3>Boiler</h3>
-                        <div aria-hidden="true" class="arrow-circle">
-                            <div class="animated-arrow">
-                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
-                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
-                            </div>
-                        </div>
-                    </a>
-                </li><li>
                     <a href="/documentation-skeleton/">
                         <h3>Documentation Skeleton</h3>
                         <div aria-hidden="true" class="arrow-circle">
@@ -182,6 +172,16 @@
                 </li><li>
                     <a href="/telemetry/">
                         <h3>Telemetry</h3>
+                        <div aria-hidden="true" class="arrow-circle">
+                            <div class="animated-arrow">
+                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                            </div>
+                        </div>
+                    </a>
+                </li><li>
+                    <a href="/boiler/">
+                        <h3>BO1LER</h3>
                         <div aria-hidden="true" class="arrow-circle">
                             <div class="animated-arrow">
                                 <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -27,7 +27,7 @@
       <header class="navi">
         <nav class="nav" role="navigation" aria-label="Main">
           <ul class="nav-links">
-            <li class="nav-item logo">
+            <li class="nav-item logo" >
               <a href="/">Deven</a>
             </li>
             <li class="nav-item subnav" id="subnav" >
@@ -50,15 +50,11 @@
                 </ul>
                 <button class="close-btn" onclick="closeSubnav()"><span class="visually-hidden">Close Discover menu</span></button>
               </div>
-            </li>
-                <li class="nav-item" >
-                  <a href="/contributors/">Contributors</a>
-                </li>
-              
-                <li class="nav-item" >
-                  <a href="/blog-post/">Blog</a>
-                </li>
-              </ul>
+            </li><li class="nav-item" >
+                <a href="/blog-post/">Blog</a>
+              </li><li class="nav-item" >
+                <a href="/contributors/">Contributors</a>
+              </li></ul>
         </nav>
       </header>
       <main class="tmpl-home home">

--- a/docs/assets/css/blog.css
+++ b/docs/assets/css/blog.css
@@ -36,6 +36,9 @@
 .project-wrapper .project-title.not-found {
   color: #000000;
 }
+.project-wrapper .project-title.wide-letters {
+  letter-spacing: 0.1em;
+}
 .project-wrapper .project-info {
   width: 100%;
   line-height: 130%;

--- a/docs/blog-post/index.html
+++ b/docs/blog-post/index.html
@@ -27,7 +27,7 @@
       <header class="navi">
         <nav class="nav" role="navigation" aria-label="Main">
           <ul class="nav-links">
-            <li class="nav-item logo">
+            <li class="nav-item logo" >
               <a href="/">Deven</a>
             </li>
             <li class="nav-item subnav" id="subnav" >
@@ -50,15 +50,11 @@
                 </ul>
                 <button class="close-btn" onclick="closeSubnav()"><span class="visually-hidden">Close Discover menu</span></button>
               </div>
-            </li>
-                <li class="nav-item" >
-                  <a href="/contributors/">Contributors</a>
-                </li>
-              
-                <li class="nav-item nav-item-active"  aria-current="page">
-                  <a href="/blog-post/">Blog</a>
-                </li>
-              </ul>
+            </li><li class="nav-item nav-item-active"  aria-current="page">
+                <a href="/blog-post/">Blog</a>
+              </li><li class="nav-item" >
+                <a href="/contributors/">Contributors</a>
+              </li></ul>
         </nav>
       </header>
       <main class="tmpl-blog home">

--- a/docs/boiler/index.html
+++ b/docs/boiler/index.html
@@ -5,7 +5,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Boiler</title>
+    <title>BO1LER</title>
     
     <link rel="icon" href="/favicon.ico" sizes="32x32">
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
@@ -66,7 +66,7 @@
 <div class="main-header blue-circle"></div>
  
 <div class="project-wrapper">
-  <h1 class="project-title">Boiler</h1>
+  <h1 class="project-title wide-letters">BO1LER</h1>
 
   <div class="project-info light">
     <div class="wrapper">

--- a/docs/boiler/index.html
+++ b/docs/boiler/index.html
@@ -27,7 +27,7 @@
       <header class="navi">
         <nav class="nav" role="navigation" aria-label="Main">
           <ul class="nav-links">
-            <li class="nav-item logo">
+            <li class="nav-item logo" >
               <a href="/">Deven</a>
             </li>
             <li class="nav-item subnav" id="subnav" >
@@ -50,15 +50,11 @@
                 </ul>
                 <button class="close-btn" onclick="closeSubnav()"><span class="visually-hidden">Close Discover menu</span></button>
               </div>
-            </li>
-                <li class="nav-item" >
-                  <a href="/contributors/">Contributors</a>
-                </li>
-              
-                <li class="nav-item" >
-                  <a href="/blog-post/">Blog</a>
-                </li>
-              </ul>
+            </li><li class="nav-item" >
+                <a href="/blog-post/">Blog</a>
+              </li><li class="nav-item" >
+                <a href="/contributors/">Contributors</a>
+              </li></ul>
         </nav>
       </header>
       <main class="tmpl-blog home">

--- a/docs/contributors/index.html
+++ b/docs/contributors/index.html
@@ -27,7 +27,7 @@
       <header class="navi">
         <nav class="nav" role="navigation" aria-label="Main">
           <ul class="nav-links">
-            <li class="nav-item logo">
+            <li class="nav-item logo" >
               <a href="/">Deven</a>
             </li>
             <li class="nav-item subnav" id="subnav" >
@@ -50,15 +50,11 @@
                 </ul>
                 <button class="close-btn" onclick="closeSubnav()"><span class="visually-hidden">Close Discover menu</span></button>
               </div>
-            </li>
-                <li class="nav-item nav-item-active"  aria-current="page">
-                  <a href="/contributors/">Contributors</a>
-                </li>
-              
-                <li class="nav-item" >
-                  <a href="/blog-post/">Blog</a>
-                </li>
-              </ul>
+            </li><li class="nav-item" >
+                <a href="/blog-post/">Blog</a>
+              </li><li class="nav-item nav-item-active"  aria-current="page">
+                <a href="/contributors/">Contributors</a>
+              </li></ul>
         </nav>
       </header>
       <main>

--- a/docs/documentation-skeleton/index.html
+++ b/docs/documentation-skeleton/index.html
@@ -27,7 +27,7 @@
       <header class="navi">
         <nav class="nav" role="navigation" aria-label="Main">
           <ul class="nav-links">
-            <li class="nav-item logo">
+            <li class="nav-item logo" >
               <a href="/">Deven</a>
             </li>
             <li class="nav-item subnav" id="subnav" >
@@ -50,15 +50,11 @@
                 </ul>
                 <button class="close-btn" onclick="closeSubnav()"><span class="visually-hidden">Close Discover menu</span></button>
               </div>
-            </li>
-                <li class="nav-item" >
-                  <a href="/contributors/">Contributors</a>
-                </li>
-              
-                <li class="nav-item" >
-                  <a href="/blog-post/">Blog</a>
-                </li>
-              </ul>
+            </li><li class="nav-item" >
+                <a href="/blog-post/">Blog</a>
+              </li><li class="nav-item" >
+                <a href="/contributors/">Contributors</a>
+              </li></ul>
         </nav>
       </header>
       <main class="tmpl-blog home">

--- a/docs/imprint/index.html
+++ b/docs/imprint/index.html
@@ -27,7 +27,7 @@
       <header class="navi">
         <nav class="nav" role="navigation" aria-label="Main">
           <ul class="nav-links">
-            <li class="nav-item logo">
+            <li class="nav-item logo" >
               <a href="/">Deven</a>
             </li>
             <li class="nav-item subnav" id="subnav" >
@@ -50,15 +50,11 @@
                 </ul>
                 <button class="close-btn" onclick="closeSubnav()"><span class="visually-hidden">Close Discover menu</span></button>
               </div>
-            </li>
-                <li class="nav-item" >
-                  <a href="/contributors/">Contributors</a>
-                </li>
-              
-                <li class="nav-item" >
-                  <a href="/blog-post/">Blog</a>
-                </li>
-              </ul>
+            </li><li class="nav-item" >
+                <a href="/blog-post/">Blog</a>
+              </li><li class="nav-item" >
+                <a href="/contributors/">Contributors</a>
+              </li></ul>
         </nav>
       </header>
       <main>

--- a/docs/index.html
+++ b/docs/index.html
@@ -158,105 +158,93 @@
                 </symbol>
             </defs>
         </svg>
-        <ul>
-            <li>
-                <a href='./documentation-skeleton'>
-                    <h3>Documentation Skeleton</h3>
-                    <div aria-hidden="true" class="arrow-circle">
-                        <div class="animated-arrow">
-                            <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
-                            <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+
+        <ul><li>
+                    <a href="/boiler/">
+                        <h3>Boiler</h3>
+                        <div aria-hidden="true" class="arrow-circle">
+                            <div class="animated-arrow">
+                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                            </div>
                         </div>
-                    </div>
-                </a>
-            </li>
-            <li>
-                <a href='./telemetry'>
-                    <h3>Telemetry</h3>
-                    <div aria-hidden="true" class="arrow-circle">
-                        <div class="animated-arrow">
-                            <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
-                            <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                    </a>
+                </li><li>
+                    <a href="/documentation-skeleton/">
+                        <h3>Documentation Skeleton</h3>
+                        <div aria-hidden="true" class="arrow-circle">
+                            <div class="animated-arrow">
+                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                            </div>
                         </div>
-                    </div>
-                </a>
-            </li>
-            <li>
-                <a href='./boiler'>
-                    <h3>BO1LER</h3>
-                    <div aria-hidden="true" class="arrow-circle">
-                        <div class="animated-arrow">
-                            <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
-                            <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                    </a>
+                </li><li>
+                    <a href="/telemetry/">
+                        <h3>Telemetry</h3>
+                        <div aria-hidden="true" class="arrow-circle">
+                            <div class="animated-arrow">
+                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                            </div>
                         </div>
-                    </div>
-                </a>
-            </li>
-        </ul>
+                    </a>
+                </li></ul>
     </div>
 
     <div class="current-team" id='team'>
         <div class="team-title"> 
             <h2 class="november-font">current team</h2>
         </div>
-        <div class="team-members">
-            <div class="team-member">
-                <img src="./assets/images/ola.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">Ola Gasidlo-Brändel</h3>
-                    <p class="member-title">Project Lead</p>
-                </div>
-            </div>
-            <div class="team-member">
-                <img src="./assets/images/simon.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">Simon Novak</h3>
-                    <p class="member-title">Product Owner</p>
-                </div>
-            </div>
-            <div class="team-member">
-                <img src="./assets/images/giordana.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">Giordana Furquim</h3>
-                    <p class="member-title">Technical Product Owner</p>
-                </div>
-            </div>
-            <div class="team-member">
-                <img src="./assets/images/raffaele.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">Raffaele Pizzari</h3>
-                    <p class="member-title">Lead Product Engineer</p>
-                </div>
-            </div>
-            <div class="team-member">
-                <img src="./assets/images/ross.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">Ross DiLiegro</h3>
-                    <p class="member-title">Product Engineer</p>
-                </div>
-            </div>
-            <div class="team-member">
-                <img src="./assets/images/david.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">David Kennedy</h3>
-                    <p class="member-title">Product Engineer</p>
-                </div>
-            </div>
-            <div class="team-member">
-                <img src="./assets/images/kundan.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">Kundan Pawar</h3>
-                    <p class="member-title">Product Engineer</p>
-                </div>
-            </div>
-            <div class="team-member">
-                <img src="./assets/images/ania.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">Ania Bui</h3>
-                    <p class="member-title">Product Designer</p>
-                </div>
-            </div>
-        </div>
+        <div class="team-members"><div class="team-member">
+                    <img src="/assets/images/ola.jpg" alt="" class="member-pic">
+                    <div class="member-info">
+                        <h3 class="member-name">Ola Gasidlo-Brändel</h3>
+                        <p class="member-title">Project Lead</p>
+                    </div>
+                </div><div class="team-member">
+                    <img src="/assets/images/simon.jpg" alt="" class="member-pic">
+                    <div class="member-info">
+                        <h3 class="member-name">Simon Novak</h3>
+                        <p class="member-title">Product Owner</p>
+                    </div>
+                </div><div class="team-member">
+                    <img src="/assets/images/giordana.jpg" alt="" class="member-pic">
+                    <div class="member-info">
+                        <h3 class="member-name">Giordana Furquim</h3>
+                        <p class="member-title">Technical Product Owner</p>
+                    </div>
+                </div><div class="team-member">
+                    <img src="/assets/images/raffaele.jpg" alt="" class="member-pic">
+                    <div class="member-info">
+                        <h3 class="member-name">Raffaele Pizzari</h3>
+                        <p class="member-title">Lead Product Engineer</p>
+                    </div>
+                </div><div class="team-member">
+                    <img src="/assets/images/ross.jpg" alt="" class="member-pic">
+                    <div class="member-info">
+                        <h3 class="member-name">Ross DiLiegro</h3>
+                        <p class="member-title">Product Engineer</p>
+                    </div>
+                </div><div class="team-member">
+                    <img src="/assets/images/david.jpg" alt="" class="member-pic">
+                    <div class="member-info">
+                        <h3 class="member-name">David Kennedy</h3>
+                        <p class="member-title">Product Engineer</p>
+                    </div>
+                </div><div class="team-member">
+                    <img src="/assets/images/kundan.jpg" alt="" class="member-pic">
+                    <div class="member-info">
+                        <h3 class="member-name">Kundan Pawar</h3>
+                        <p class="member-title">Product Engineer</p>
+                    </div>
+                </div><div class="team-member">
+                    <img src="/assets/images/ania.jpg" alt="" class="member-pic">
+                    <div class="member-info">
+                        <h3 class="member-name">Ania Bui</h3>
+                        <p class="member-title">Product Designer</p>
+                    </div>
+                </div></div>
         <a href='./contributors' class="cta-btn">
             <span>Contributors <span aria-hidden="true">→</span></span>
         </a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -160,16 +160,6 @@
         </svg>
 
         <ul><li>
-                    <a href="/boiler/">
-                        <h3>Boiler</h3>
-                        <div aria-hidden="true" class="arrow-circle">
-                            <div class="animated-arrow">
-                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
-                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
-                            </div>
-                        </div>
-                    </a>
-                </li><li>
                     <a href="/documentation-skeleton/">
                         <h3>Documentation Skeleton</h3>
                         <div aria-hidden="true" class="arrow-circle">
@@ -182,6 +172,16 @@
                 </li><li>
                     <a href="/telemetry/">
                         <h3>Telemetry</h3>
+                        <div aria-hidden="true" class="arrow-circle">
+                            <div class="animated-arrow">
+                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                            </div>
+                        </div>
+                    </a>
+                </li><li>
+                    <a href="/boiler/">
+                        <h3>BO1LER</h3>
                         <div aria-hidden="true" class="arrow-circle">
                             <div class="animated-arrow">
                                 <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@
       <header class="navi">
         <nav class="nav" role="navigation" aria-label="Main">
           <ul class="nav-links">
-            <li class="nav-item logo">
+            <li class="nav-item logo" >
               <a href="/">Deven</a>
             </li>
             <li class="nav-item subnav" id="subnav" >
@@ -50,15 +50,11 @@
                 </ul>
                 <button class="close-btn" onclick="closeSubnav()"><span class="visually-hidden">Close Discover menu</span></button>
               </div>
-            </li>
-                <li class="nav-item" >
-                  <a href="/contributors/">Contributors</a>
-                </li>
-              
-                <li class="nav-item" >
-                  <a href="/blog-post/">Blog</a>
-                </li>
-              </ul>
+            </li><li class="nav-item" >
+                <a href="/blog-post/">Blog</a>
+              </li><li class="nav-item" >
+                <a href="/contributors/">Contributors</a>
+              </li></ul>
         </nav>
       </header>
       <main class="tmpl-home home">

--- a/docs/posts/20170110-what-is-web-compatibility/index.html
+++ b/docs/posts/20170110-what-is-web-compatibility/index.html
@@ -27,7 +27,7 @@
       <header class="navi">
         <nav class="nav" role="navigation" aria-label="Main">
           <ul class="nav-links">
-            <li class="nav-item logo">
+            <li class="nav-item logo" >
               <a href="/">Deven</a>
             </li>
             <li class="nav-item subnav" id="subnav" >
@@ -50,15 +50,11 @@
                 </ul>
                 <button class="close-btn" onclick="closeSubnav()"><span class="visually-hidden">Close Discover menu</span></button>
               </div>
-            </li>
-                <li class="nav-item" >
-                  <a href="/contributors/">Contributors</a>
-                </li>
-              
-                <li class="nav-item" >
-                  <a href="/blog-post/">Blog</a>
-                </li>
-              </ul>
+            </li><li class="nav-item" >
+                <a href="/blog-post/">Blog</a>
+              </li><li class="nav-item" >
+                <a href="/contributors/">Contributors</a>
+              </li></ul>
         </nav>
       </header>
       <main class="tmpl-post home">

--- a/docs/posts/20170116-why-do-we-need-web-compatibility/index.html
+++ b/docs/posts/20170116-why-do-we-need-web-compatibility/index.html
@@ -27,7 +27,7 @@
       <header class="navi">
         <nav class="nav" role="navigation" aria-label="Main">
           <ul class="nav-links">
-            <li class="nav-item logo">
+            <li class="nav-item logo" >
               <a href="/">Deven</a>
             </li>
             <li class="nav-item subnav" id="subnav" >
@@ -50,15 +50,11 @@
                 </ul>
                 <button class="close-btn" onclick="closeSubnav()"><span class="visually-hidden">Close Discover menu</span></button>
               </div>
-            </li>
-                <li class="nav-item" >
-                  <a href="/contributors/">Contributors</a>
-                </li>
-              
-                <li class="nav-item" >
-                  <a href="/blog-post/">Blog</a>
-                </li>
-              </ul>
+            </li><li class="nav-item" >
+                <a href="/blog-post/">Blog</a>
+              </li><li class="nav-item" >
+                <a href="/contributors/">Contributors</a>
+              </li></ul>
         </nav>
       </header>
       <main class="tmpl-post home">

--- a/docs/posts/20170404-key-to-productivity/index.html
+++ b/docs/posts/20170404-key-to-productivity/index.html
@@ -27,7 +27,7 @@
       <header class="navi">
         <nav class="nav" role="navigation" aria-label="Main">
           <ul class="nav-links">
-            <li class="nav-item logo">
+            <li class="nav-item logo" >
               <a href="/">Deven</a>
             </li>
             <li class="nav-item subnav" id="subnav" >
@@ -50,15 +50,11 @@
                 </ul>
                 <button class="close-btn" onclick="closeSubnav()"><span class="visually-hidden">Close Discover menu</span></button>
               </div>
-            </li>
-                <li class="nav-item" >
-                  <a href="/contributors/">Contributors</a>
-                </li>
-              
-                <li class="nav-item" >
-                  <a href="/blog-post/">Blog</a>
-                </li>
-              </ul>
+            </li><li class="nav-item" >
+                <a href="/blog-post/">Blog</a>
+              </li><li class="nav-item" >
+                <a href="/contributors/">Contributors</a>
+              </li></ul>
         </nav>
       </header>
       <main class="tmpl-post home">

--- a/docs/telemetry/index.html
+++ b/docs/telemetry/index.html
@@ -27,7 +27,7 @@
       <header class="navi">
         <nav class="nav" role="navigation" aria-label="Main">
           <ul class="nav-links">
-            <li class="nav-item logo">
+            <li class="nav-item logo" >
               <a href="/">Deven</a>
             </li>
             <li class="nav-item subnav" id="subnav" >
@@ -50,15 +50,11 @@
                 </ul>
                 <button class="close-btn" onclick="closeSubnav()"><span class="visually-hidden">Close Discover menu</span></button>
               </div>
-            </li>
-                <li class="nav-item" >
-                  <a href="/contributors/">Contributors</a>
-                </li>
-              
-                <li class="nav-item" >
-                  <a href="/blog-post/">Blog</a>
-                </li>
-              </ul>
+            </li><li class="nav-item" >
+                <a href="/blog-post/">Blog</a>
+              </li><li class="nav-item" >
+                <a href="/contributors/">Contributors</a>
+              </li></ul>
         </nav>
       </header>
       <main class="tmpl-blog home">

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -66,6 +66,8 @@ module.exports = (eleventyConfig) => {
     return content
   })
 
+  eleventyConfig.setNunjucksEnvironmentOptions({ throwOnUndefined: true })
+
   // Adds SCSS compiling
   eleventyConfig.addTemplateFormats('scss')
 
@@ -83,6 +85,7 @@ module.exports = (eleventyConfig) => {
       }
     },
   })
+
   return {
     templateFormats: ['md', 'html', 'njk'],
     markdownTemplateEngine: 'liquid',

--- a/src/_data/team.json
+++ b/src/_data/team.json
@@ -1,0 +1,49 @@
+[
+  {
+    "name": "Ola Gasidlo-Brändel",
+    "role": "Project Lead",
+    "imageUrl": "/assets/images/ola.jpg"
+  },
+
+  {
+    "name": "Simon Novak",
+    "role": "Product Owner",
+    "imageUrl": "/assets/images/simon.jpg"
+  },
+
+  {
+    "name": "Giordana Furquim",
+    "role": "Technical Product Owner",
+    "imageUrl": "/assets/images/giordana.jpg"
+  },
+
+  {
+    "name": "Raffaele Pizzari",
+    "role": "Lead Product Engineer",
+    "imageUrl": "/assets/images/raffaele.jpg"
+  },
+
+  {
+    "name": "Ross DiLiegro",
+    "role": "Product Engineer",
+    "imageUrl": "/assets/images/ross.jpg"
+  },
+
+  {
+    "name": "David Kennedy",
+    "role": "Product Engineer",
+    "imageUrl": "/assets/images/david.jpg"
+  },
+
+  {
+    "name": "Kundan Pawar",
+    "role": "Product Engineer",
+    "imageUrl": "/assets/images/kundan.jpg"
+  },
+
+  {
+    "name": "Ania Bui",
+    "role": "Product Designer",
+    "imageUrl": "/assets/images/ania.jpg"
+  }
+]

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -30,7 +30,7 @@
       <header class="navi">
         <nav class="nav" role="navigation" aria-label="Main">
           <ul class="nav-links">
-            <li class="nav-item logo">
+            <li class="nav-item logo" >
               <a href="/">Deven</a>
             </li>
             <li class="nav-item subnav" id="subnav" >
@@ -54,12 +54,10 @@
                 <button class="close-btn" onclick="closeSubnav()"><span class="visually-hidden">Close Discover menu</span></button>
               </div>
             </li>
-            {%- for nav in collections.nav | reverse -%}
-              {% if nav.data.navtitle %}
-                <li class="nav-item{% if nav.url == page.url %} nav-item-active{% endif %}" {% if nav.url == page.url %} aria-current="page"{% endif %}>
-                  <a href="{{ nav.url }}">{{ nav.data.navtitle }}</a>
-                </li>
-              {% endif %}
+            {%- for nav in collections.navItems | sort(attribute="data.navOrder") -%}
+              <li class="nav-item{% if nav.url == page.url %} nav-item-active{% endif %}" {% if nav.url == page.url %} aria-current="page"{% endif %}>
+                <a href="{{ nav.url }}">{{ nav.data.title }}</a>
+              </li>
             {%- endfor -%}
           </ul>
         </nav>

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -99,40 +99,21 @@ comingSoonClass: footer-circle
                 </symbol>
             </defs>
         </svg>
+
         <ul>
-            <li>
-                <a href='./documentation-skeleton'>
-                    <h3>Documentation Skeleton</h3>
-                    <div aria-hidden="true" class="arrow-circle">
-                        <div class="animated-arrow">
-                            <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
-                            <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+            {%- for tool in collections.tool -%}
+                <li>
+                    <a href="{{ tool.url }}">
+                        <h3>{{ tool.data.title }}</h3>
+                        <div aria-hidden="true" class="arrow-circle">
+                            <div class="animated-arrow">
+                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                                <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
+                            </div>
                         </div>
-                    </div>
-                </a>
-            </li>
-            <li>
-                <a href='./telemetry'>
-                    <h3>Telemetry</h3>
-                    <div aria-hidden="true" class="arrow-circle">
-                        <div class="animated-arrow">
-                            <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
-                            <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
-                        </div>
-                    </div>
-                </a>
-            </li>
-            <li>
-                <a href='./boiler'>
-                    <h3>BO1LER</h3>
-                    <div aria-hidden="true" class="arrow-circle">
-                        <div class="animated-arrow">
-                            <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
-                            <svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><use href="#icon-sliding-arrow" /></svg>
-                        </div>
-                    </div>
-                </a>
-            </li>
+                    </a>
+                </li>
+            {%- endfor -%}
         </ul>
     </div>
 
@@ -141,62 +122,15 @@ comingSoonClass: footer-circle
             <h2 class="november-font">current team</h2>
         </div>
         <div class="team-members">
-            <div class="team-member">
-                <img src="./assets/images/ola.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">Ola Gasidlo-Brändel</h3>
-                    <p class="member-title">Project Lead</p>
+            {%- for member in team -%}
+                <div class="team-member">
+                    <img src="{{ member.imageUrl }}" alt="" class="member-pic">
+                    <div class="member-info">
+                        <h3 class="member-name">{{ member.name }}</h3>
+                        <p class="member-title">{{ member.role }}</p>
+                    </div>
                 </div>
-            </div>
-            <div class="team-member">
-                <img src="./assets/images/simon.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">Simon Novak</h3>
-                    <p class="member-title">Product Owner</p>
-                </div>
-            </div>
-            <div class="team-member">
-                <img src="./assets/images/giordana.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">Giordana Furquim</h3>
-                    <p class="member-title">Technical Product Owner</p>
-                </div>
-            </div>
-            <div class="team-member">
-                <img src="./assets/images/raffaele.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">Raffaele Pizzari</h3>
-                    <p class="member-title">Lead Product Engineer</p>
-                </div>
-            </div>
-            <div class="team-member">
-                <img src="./assets/images/ross.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">Ross DiLiegro</h3>
-                    <p class="member-title">Product Engineer</p>
-                </div>
-            </div>
-            <div class="team-member">
-                <img src="./assets/images/david.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">David Kennedy</h3>
-                    <p class="member-title">Product Engineer</p>
-                </div>
-            </div>
-            <div class="team-member">
-                <img src="./assets/images/kundan.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">Kundan Pawar</h3>
-                    <p class="member-title">Product Engineer</p>
-                </div>
-            </div>
-            <div class="team-member">
-                <img src="./assets/images/ania.jpg" alt="" class="member-pic">
-                <div class="member-info">
-                    <h3 class="member-name">Ania Bui</h3>
-                    <p class="member-title">Product Designer</p>
-                </div>
-            </div>
+            {%- endfor -%}
         </div>
         <a href='./contributors' class="cta-btn">
             <span>Contributors <span aria-hidden="true">→</span></span>

--- a/src/assets/css/blog.scss
+++ b/src/assets/css/blog.scss
@@ -26,7 +26,7 @@
   margin-top: 0%;
   padding: 70px 10px 0px 10px;
   .project-title {
-    font-family: "november";
+    font-family: 'november';
     font-weight: 400;
     font-size: 45px;
     line-height: 5rem;
@@ -37,6 +37,9 @@
     padding: 100px 0px 80px 0px;
     &.not-found {
       color: #000000;
+    }
+    &.wide-letters {
+      letter-spacing: 0.1em;
     }
   }
   .project-info {
@@ -50,30 +53,30 @@
     .wrapper {
       h1,
       h2 {
-        font-family: "space-grotesk-bold";
+        font-family: 'space-grotesk-bold';
         font-size: 1.8rem;
         padding-bottom: 2rem;
       }
       h3 {
         margin-top: 2rem;
-        font-family: "space-grotesk-bold";
+        font-family: 'space-grotesk-bold';
         font-size: 1.1rem;
         padding-bottom: 1rem;
       }
       p {
-        font-family: "space-grotesk-light";
+        font-family: 'space-grotesk-light';
         font-size: 0.9rem;
         display: block;
         padding: 0.5rem 0;
         strong {
-          font-family: "space-grotesk-bold";
+          font-family: 'space-grotesk-bold';
         }
       }
       code {
         color: black;
         background-color: #f7f7f7;
         border-radius: 10px;
-        font-family: "space-grotesk-bold";
+        font-family: 'space-grotesk-bold';
         padding: 1rem 1.5rem;
         margin: 20px auto;
         display: block;
@@ -142,7 +145,7 @@
 }
 
 .coming-soon {
-  font-family: "november";
+  font-family: 'november';
   font-weight: 400;
   font-size: 45px;
   line-height: 5rem;
@@ -205,7 +208,7 @@
     p {
       font-size: 14px;
       font-weight: 700;
-      font-family: "space-grotesk-light";
+      font-family: 'space-grotesk-light';
       color: #111111;
     }
   }
@@ -215,7 +218,7 @@
       text-decoration: none;
       font-size: 18px;
       font-weight: 700;
-      font-family: "space-grotesk-bold";
+      font-family: 'space-grotesk-bold';
       color: #000;
       cursor: pointer;
       &:hover {

--- a/src/blog-post.njk
+++ b/src/blog-post.njk
@@ -1,8 +1,8 @@
 ---
 layout: layouts/blog.njk
 tags:
-  - nav
-navtitle: Blog
+  - navItems
+navOrder: 10
 title: Blog
 templateClass: tmpl-blog
 ---

--- a/src/boiler.njk
+++ b/src/boiler.njk
@@ -1,12 +1,12 @@
 ---
 layout: layouts/blog.njk
-title: Boiler
+title: BO1LER
 tags:
   - tool
 ---
 
 <div class="project-wrapper">
-  <h1 class="project-title">{{ title }}</h1>
+  <h1 class="project-title wide-letters">{{ title }}</h1>
 
   <div class="project-info light">
     <div class="wrapper">

--- a/src/boiler.njk
+++ b/src/boiler.njk
@@ -1,6 +1,8 @@
 ---
 layout: layouts/blog.njk
 title: Boiler
+tags:
+  - tool
 ---
 
 <div class="project-wrapper">

--- a/src/contributors.njk
+++ b/src/contributors.njk
@@ -1,8 +1,8 @@
 ---
 layout: layouts/base.njk
 tags:
-  - nav
-navtitle: Contributors
+  - navItems
+navOrder: 20
 title: Contributors
 ---
 

--- a/src/documentation-skeleton.njk
+++ b/src/documentation-skeleton.njk
@@ -1,6 +1,8 @@
 ---
 layout: layouts/blog.njk
 title: Documentation Skeleton
+tags:
+  - tool
 ---
 
 <div class="project-wrapper">

--- a/src/index.njk
+++ b/src/index.njk
@@ -1,7 +1,5 @@
 ---
 layout: layouts/home.njk
-tags:
-  - nav
 title: DEVENorg
 ---
 

--- a/src/telemetry.njk
+++ b/src/telemetry.njk
@@ -1,6 +1,8 @@
 ---
 layout: layouts/blog.njk
 title: Telemetry
+tags:
+  - tool
 ---
 
 <div class="project-wrapper">


### PR DESCRIPTION
Small refactor to have less duplication in our code. Draft, because it was build on top of #131 for now.

Note that the tool links currently have an inferred sorting (I think it's just alphabetical?), I didn't add anything else because it's not clear to me what we would want.

Also, this changes the link on the home page from "BO1LER" to "Boiler" because that is the page's title. We could either change the page title to "BO1LER", or add a field in the data to have a secondary name for the list.
I do prefer the consistency here, I think it would make sense to align them either way? 