### PR TITLE
feat: load contributor images from github

### DIFF
--- a/docs/assets/css/contributors.css
+++ b/docs/assets/css/contributors.css
@@ -288,3 +288,11 @@
   height: auto;
   padding: 10px 20px;
 }
+
+.fetch-status {
+  font-family: "space-grotesk-bold";
+  margin: 5rem auto 5rem auto;
+  text-align: center;
+  font-size: 2rem;
+  color: #f7f7f7;
+}

--- a/docs/contributors/index.html
+++ b/docs/contributors/index.html
@@ -82,56 +82,158 @@
     </div>
   </div>
 </section>
-<section class="contributors">
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
+<section aria-label="List of GitHub contributors">
+  <div class="fetch-status" id="contributors-fetch-status">
+    <span class="status-loading" id="contributors-status-loading">Loading Contributors… ⏳</span>
+    <span aria-live="polite" hidden class="status-error" id="contributors-status-error">Could not load GitHub Contributors 😔</span>
   </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
+  <div class="contributors" id="contributors" hidden>
+    
   </div>
 </section>
+<script type="module">
+  // Unauthenticated REST endpoints are rate limited at usually 60req/IP/hour
+  // So we try to cache results in localStorage for an hour
+  const CACHE_RETENTION_MS = 1000 * 60 * 60;
+  const GITHUB_API_VERSION = "2022-11-28";
+  const LOCAL_STORAGE_CACHE_KEY = "contrib-cache";
+
+  function getCachedContributors() {
+    /*
+      Cache format v1
+
+      {
+        updated_at: number,
+        version: 1,
+        contributors: {
+          id: number,
+          login: string,
+          avatar_url: string,
+          html_url: string,
+          contributions: number,
+        }[]
+      }
+    */
+    const cachedUsers = JSON.parse(localStorage.getItem(LOCAL_STORAGE_CACHE_KEY));
+
+    if (!cachedUsers || cachedUsers.version !== 1) {
+      return null;
+    }
+
+    if (Date.now() - cachedUsers.updated_at > CACHE_RETENTION_MS) {
+      localStorage.removeItem(LOCAL_STORAGE_CACHE_KEY);
+      return null;
+    }
+
+    return cachedUsers.contributors;
+  }
+
+  function cacheContributors(contributors) {
+    const cacheData = JSON.stringify({
+      updated_at: Date.now(),
+      version: 1,
+      contributors,
+    });
+    localStorage.setItem(LOCAL_STORAGE_CACHE_KEY, cacheData);
+  }
+
+  async function fetchGithubJson(endpoint) {
+    const response = await fetch(`https://api.github.com${endpoint}`, {
+      headers: { "X-GitHub-Api-Version": GITHUB_API_VERSION }
+    });
+
+    if (!response.ok) {
+      throw new Error("Unknown error fetching from GitHub");
+    }
+
+    return await response.json();
+  }
+
+  async function fetchDevenContributors() {
+    const cached = getCachedContributors();
+
+    if (cached) {
+      return cached;
+    }
+
+    // Step 1: Fetch all public repos in deven-org
+    const orgRepos = await fetchGithubJson("/orgs/deven-org/repos");
+    // Step 2: Fetch all contributors for each repo
+    const contributorsResults = await Promise.allSettled(
+        orgRepos.map(repo => fetchGithubJson(`/repos/${repo.full_name}/contributors`))
+    );
+
+    // Using Promise.allSettled with this filter ignores partial fails
+    // i.e. if one repo cannot be fetched, we will ignore this
+    const contributorsLists = contributorsResults
+      .filter(res => res.status === "fulfilled" && res.value.length > 0)
+      .map(res => res.value);
+
+    const dedupedList = [];
+
+    for (const list of contributorsLists) {
+      for (const user of list) {
+        if (user.type !== "User") {
+          continue;
+        }
+
+        const existing = dedupedList.find(u => u.id === user.id);
+        if (existing) {
+          existing.contributions += user.contributions
+        } else {
+          const { id, login, avatar_url, html_url, contributions } = user;
+          dedupedList.push({ id, login, avatar_url, html_url, contributions });
+        }
+      }
+    }
+
+    if (dedupedList.length === 0) {
+      throw new Error("No contributors found");
+    }
+
+    dedupedList.sort((a, b) => b.contributions - a.contributions); // descending
+
+    cacheContributors(dedupedList);
+
+    return dedupedList;
+  }
+
+
+  fetchDevenContributors().then((contributors) => {
+    const contributorsSection = document.getElementById("contributors");
+
+    for (const user of contributors) {
+      /*
+        We're generating this:
+
+        <a href={user.html_url} class="image-container">
+          <img class="contributor-pic" src={user.avatar_url} alt={user.login} title={user.login} />
+        </a>
+      */
+
+      const userLink = document.createElement("a");
+      userLink.classList.add("image-container");
+      userLink.href = user.html_url;
+
+      const image = document.createElement("img");
+      image.src = user.avatar_url;
+      image.alt = user.login;
+      image.title = user.login;
+      image.classList.add("contributor-pic");
+
+      userLink.appendChild(image);
+      contributorsSection.appendChild(userLink);
+    }
+
+    document.getElementById("contributors-fetch-status").setAttribute("hidden", "");
+    contributorsSection.removeAttribute("hidden");
+  }).catch((e) => {
+    console.warn("An error occured while fetching the GitHub contributor list");
+    console.error(e);
+    document.getElementById("contributors-status-loading").setAttribute("hidden", "");
+    document.getElementById("contributors-status-error").removeAttribute("hidden");
+  });
+</script>
       </main>
       <footer id="latest-news">
         <div  style="display:none;"  class="blog-content">

--- a/src/assets/css/contributors.scss
+++ b/src/assets/css/contributors.scss
@@ -12,231 +12,249 @@ $screen-xl-min: 1200px;
 // Small devices
 @mixin sm {
   @media (min-width: #{$screen-sm-min}) {
-      @content;
+    @content;
   }
 }
 
 // Medium devices
 @mixin md {
   @media (min-width: #{$screen-md-min}) {
-      @content;
+    @content;
   }
 }
 
 // Large devices
 @mixin lg {
   @media (min-width: #{$screen-lg-min}) {
-      @content;
+    @content;
   }
 }
 
 // Extra large devices
 @mixin xl {
   @media (min-width: #{$screen-xl-min}) {
-      @content;
+    @content;
   }
-}  
+}
 
 .content-wrapper {
-    width: 100%;
-    //max-width: 960px;
-    margin: 0 auto;
+  width: 100%;
+  //max-width: 960px;
+  margin: 0 auto;
 }
 
 .people-icon {
-    display: flex;
-    justify-content: center;
-    padding-top: 120px;
-    svg {
-        max-width: 200px;
-    }
+  display: flex;
+  justify-content: center;
+  padding-top: 120px;
+  svg {
+    max-width: 200px;
+  }
 }
 
 @mixin keyframes($name) {
-    @-webkit-keyframes #{$name} { @content }
-    @-moz-keyframes #{$name} { @content }
-    @-o-keyframes #{$name} { @content }
-    @keyframes #{$name} { @content }
+  @-webkit-keyframes #{$name} {
+    @content;
   }
+  @-moz-keyframes #{$name} {
+    @content;
+  }
+  @-o-keyframes #{$name} {
+    @content;
+  }
+  @keyframes #{$name} {
+    @content;
+  }
+}
 
 @include keyframes(pulse) {
-    0%, 20% {
-      transform: scale(1);
-    }
-    30% {
-      transform: scale(1.01);
-    }
-    50% {
-      transform: scale(1);
-    }
-    60% {
-      transform: scale(1.01);
-    }
-    70%, 100% {
-      transform: scale(1);
-    }
+  0%,
+  20% {
+    transform: scale(1);
+  }
+  30% {
+    transform: scale(1.01);
+  }
+  50% {
+    transform: scale(1);
+  }
+  60% {
+    transform: scale(1.01);
+  }
+  70%,
+  100% {
+    transform: scale(1);
+  }
 }
 
 @include keyframes(rotateStar) {
-    from {
-        transform: rotate(0deg)
-    }
-    to {
-        transform: rotate(360deg)
-    }
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .contribute {
-    position: relative;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  max-width: 1200px;
+  margin: 4rem auto;
+  padding: 0 1rem;
+  @include md {
+    padding: 0;
+  }
+  .heart {
+    background-image: url("data:image/svg+xml,%3Csvg width='567' height='524' viewBox='0 0 567 524' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M283.5 524C286.136 524 289.28 523.288 292.93 521.865C296.783 520.442 300.129 518.713 302.968 516.68C356.504 482.316 403.045 446.325 442.589 408.708C482.132 370.887 512.754 332.151 534.452 292.501C556.151 252.85 567 212.691 567 172.023C567 146.809 562.944 123.731 554.833 102.787C546.924 81.8432 535.669 63.6445 521.068 48.1909C506.67 32.7373 489.839 20.8421 470.573 12.5052C451.511 4.16841 430.725 0 408.216 0C380.433 0 355.896 7.1168 334.603 21.3504C313.31 35.584 296.276 54.596 283.5 78.3865C270.927 54.7994 253.893 35.889 232.397 21.6554C210.901 7.21847 186.364 0 158.784 0C136.275 0 115.387 4.16841 96.1223 12.5052C76.8573 20.8421 60.0258 32.7373 45.6277 48.1909C31.2296 63.6445 19.9748 81.8432 11.8632 102.787C3.9544 123.731 0 146.809 0 172.023C0 212.691 10.8493 252.85 32.5477 292.501C54.2462 332.151 84.8675 370.887 124.411 408.708C163.955 446.325 210.496 482.316 264.032 516.68C266.871 518.713 270.116 520.442 273.766 521.865C277.416 523.288 280.661 524 283.5 524Z' fill='%232154D6'/%3E%3C/svg%3E");
+    width: 350px;
+    height: 350px;
+    background-repeat: no-repeat;
+    background-size: contain;
     display: flex;
-    align-items: center;
     justify-content: center;
-    flex-wrap: wrap;
-    max-width: 1200px;
-    margin: 4rem auto;
-    padding: 0 1rem;
-    @include md {
-        padding: 0;
+    align-items: center;
+    animation: pulse 2s linear infinite alternate;
+    @include sm {
+      width: 480px;
+      height: 480px;
     }
-    .heart {
-        background-image: url("data:image/svg+xml,%3Csvg width='567' height='524' viewBox='0 0 567 524' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M283.5 524C286.136 524 289.28 523.288 292.93 521.865C296.783 520.442 300.129 518.713 302.968 516.68C356.504 482.316 403.045 446.325 442.589 408.708C482.132 370.887 512.754 332.151 534.452 292.501C556.151 252.85 567 212.691 567 172.023C567 146.809 562.944 123.731 554.833 102.787C546.924 81.8432 535.669 63.6445 521.068 48.1909C506.67 32.7373 489.839 20.8421 470.573 12.5052C451.511 4.16841 430.725 0 408.216 0C380.433 0 355.896 7.1168 334.603 21.3504C313.31 35.584 296.276 54.596 283.5 78.3865C270.927 54.7994 253.893 35.889 232.397 21.6554C210.901 7.21847 186.364 0 158.784 0C136.275 0 115.387 4.16841 96.1223 12.5052C76.8573 20.8421 60.0258 32.7373 45.6277 48.1909C31.2296 63.6445 19.9748 81.8432 11.8632 102.787C3.9544 123.731 0 146.809 0 172.023C0 212.691 10.8493 252.85 32.5477 292.501C54.2462 332.151 84.8675 370.887 124.411 408.708C163.955 446.325 210.496 482.316 264.032 516.68C266.871 518.713 270.116 520.442 273.766 521.865C277.416 523.288 280.661 524 283.5 524Z' fill='%232154D6'/%3E%3C/svg%3E");
-        width: 350px;
-        height: 350px;
-        background-repeat: no-repeat;
-        background-size: contain;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        animation: pulse 2s linear infinite alternate;
+    .inner {
+      padding: 10px;
+      display: flex;
+      flex-direction: column;
+      max-width: 67%;
+      align-items: center;
+      text-align: center;
+      margin-top: -60px;
+      @include md {
+        margin-top: -60px;
+      }
+      h2 {
+        font-family: 'space-grotesk-bold';
+        font-size: 16px;
+        line-height: 22px;
+        color: #f7f7f7;
+        padding-bottom: 10px;
         @include sm {
-            width: 480px;
-            height: 480px;
+          font-size: 22px;
+          line-height: 28px;
         }
-        .inner {
-            padding: 10px;
-            display: flex;
-            flex-direction: column;
-            max-width: 67%;
-            align-items: center;
-            text-align: center;
-            margin-top: -60px;
-            @include md {
-                margin-top: -60px;
-            }
-            h2 {
-                font-family: "space-grotesk-bold";
-                font-size: 16px;
-                line-height: 22px;
-                color: #f7f7f7;
-                padding-bottom: 10px;
-                @include sm {
-                    font-size: 22px;
-                    line-height: 28px;
-                }
-            }
-            p {
-                font-size: 9px;
-                line-height: 14px;
-                font-family: "space-grotesk-light";
-                color: #f7f7f7;
-                @include md {
-                    font-size: 13px;
-                    line-height: 18px;
-                }
-            }
+      }
+      p {
+        font-size: 9px;
+        line-height: 14px;
+        font-family: 'space-grotesk-light';
+        color: #f7f7f7;
+        @include md {
+          font-size: 13px;
+          line-height: 18px;
         }
+      }
     }
-    .star {
-        background-image: url("data:image/svg+xml,%3Csvg width='715' height='715' viewBox='0 0 715 715' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.76313 359.424C-0.173976 358.873 -0.173965 356.127 1.76314 355.576L140.424 316.136C141.992 315.69 142.397 313.656 141.119 312.644L28.1058 223.143C26.527 221.892 27.5776 219.356 29.5781 219.588L172.778 236.213C174.397 236.401 175.549 234.677 174.756 233.253L104.596 107.316C103.616 105.557 105.557 103.616 107.316 104.596L233.253 174.756C234.677 175.549 236.401 174.397 236.213 172.778L219.588 29.5782C219.356 27.5777 221.892 26.5271 223.143 28.1059L312.644 141.119C313.656 142.397 315.69 141.992 316.136 140.424L355.576 1.76319C356.127 -0.173915 358.873 -0.173904 359.424 1.7632L398.864 140.424C399.31 141.992 401.344 142.397 402.356 141.119L491.857 28.1059C493.108 26.5271 495.644 27.5777 495.412 29.5782L478.787 172.778C478.599 174.397 480.323 175.549 481.747 174.756L607.684 104.596C609.443 103.616 611.384 105.557 610.404 107.316L540.245 233.253C539.451 234.677 540.603 236.401 542.222 236.213L685.422 219.588C687.422 219.356 688.473 221.892 686.894 223.143L573.881 312.644C572.603 313.656 573.008 315.69 574.576 316.136L713.237 355.576C715.174 356.127 715.174 358.873 713.237 359.424L574.576 398.864C573.008 399.31 572.603 401.344 573.881 402.356L686.894 491.857C688.473 493.108 687.422 495.644 685.422 495.412L542.222 478.787C540.603 478.599 539.451 480.323 540.245 481.747L610.404 607.684C611.384 609.443 609.443 611.384 607.684 610.404L481.747 540.244C480.323 539.451 478.599 540.603 478.787 542.222L495.412 685.422C495.644 687.422 493.108 688.473 491.857 686.894L402.356 573.881C401.344 572.603 399.31 573.008 398.864 574.576L359.424 713.237C358.873 715.174 356.127 715.174 355.576 713.237L316.136 574.576C315.69 573.008 313.656 572.603 312.644 573.881L223.143 686.894C221.892 688.473 219.356 687.422 219.588 685.422L236.213 542.222C236.401 540.603 234.677 539.451 233.253 540.244L107.316 610.404C105.557 611.384 103.616 609.443 104.596 607.684L174.756 481.747C175.549 480.323 174.397 478.599 172.778 478.787L29.5782 495.412C27.5777 495.644 26.527 493.108 28.1058 491.857L141.119 402.356C142.397 401.344 141.992 399.31 140.424 398.864L1.76313 359.424Z' fill='%23F1DE00'/%3E%3C/svg%3E");
-        width: 450px;
-        height: 450px;
-        background-repeat: no-repeat;
-        background-size: 100% 100%;
-        display: flex;
-        margin-left: 0;
-        margin-top: -6rem;
-        justify-content: center;
-        align-items: center;
-        z-index: 1;
+  }
+  .star {
+    background-image: url("data:image/svg+xml,%3Csvg width='715' height='715' viewBox='0 0 715 715' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.76313 359.424C-0.173976 358.873 -0.173965 356.127 1.76314 355.576L140.424 316.136C141.992 315.69 142.397 313.656 141.119 312.644L28.1058 223.143C26.527 221.892 27.5776 219.356 29.5781 219.588L172.778 236.213C174.397 236.401 175.549 234.677 174.756 233.253L104.596 107.316C103.616 105.557 105.557 103.616 107.316 104.596L233.253 174.756C234.677 175.549 236.401 174.397 236.213 172.778L219.588 29.5782C219.356 27.5777 221.892 26.5271 223.143 28.1059L312.644 141.119C313.656 142.397 315.69 141.992 316.136 140.424L355.576 1.76319C356.127 -0.173915 358.873 -0.173904 359.424 1.7632L398.864 140.424C399.31 141.992 401.344 142.397 402.356 141.119L491.857 28.1059C493.108 26.5271 495.644 27.5777 495.412 29.5782L478.787 172.778C478.599 174.397 480.323 175.549 481.747 174.756L607.684 104.596C609.443 103.616 611.384 105.557 610.404 107.316L540.245 233.253C539.451 234.677 540.603 236.401 542.222 236.213L685.422 219.588C687.422 219.356 688.473 221.892 686.894 223.143L573.881 312.644C572.603 313.656 573.008 315.69 574.576 316.136L713.237 355.576C715.174 356.127 715.174 358.873 713.237 359.424L574.576 398.864C573.008 399.31 572.603 401.344 573.881 402.356L686.894 491.857C688.473 493.108 687.422 495.644 685.422 495.412L542.222 478.787C540.603 478.599 539.451 480.323 540.245 481.747L610.404 607.684C611.384 609.443 609.443 611.384 607.684 610.404L481.747 540.244C480.323 539.451 478.599 540.603 478.787 542.222L495.412 685.422C495.644 687.422 493.108 688.473 491.857 686.894L402.356 573.881C401.344 572.603 399.31 573.008 398.864 574.576L359.424 713.237C358.873 715.174 356.127 715.174 355.576 713.237L316.136 574.576C315.69 573.008 313.656 572.603 312.644 573.881L223.143 686.894C221.892 688.473 219.356 687.422 219.588 685.422L236.213 542.222C236.401 540.603 234.677 539.451 233.253 540.244L107.316 610.404C105.557 611.384 103.616 609.443 104.596 607.684L174.756 481.747C175.549 480.323 174.397 478.599 172.778 478.787L29.5782 495.412C27.5777 495.644 26.527 493.108 28.1058 491.857L141.119 402.356C142.397 401.344 141.992 399.31 140.424 398.864L1.76313 359.424Z' fill='%23F1DE00'/%3E%3C/svg%3E");
+    width: 450px;
+    height: 450px;
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
+    display: flex;
+    margin-left: 0;
+    margin-top: -6rem;
+    justify-content: center;
+    align-items: center;
+    z-index: 1;
+    @include sm {
+      width: 660px;
+      height: 660px;
+    }
+    .inner {
+      padding: 10px;
+      display: flex;
+      flex-direction: column;
+      max-width: 55%;
+      align-items: center;
+      text-align: center;
+      @include sm {
+        max-width: 45%;
+      }
+      h2 {
+        font-family: 'space-grotesk-bold';
+        font-size: 16px;
+        line-height: 22px;
+        color: black;
+        padding: 10px 15px 5px 15px;
         @include sm {
-            width: 660px;
-            height: 660px;
+          padding: 10px 35px;
+          font-size: 22px;
+          line-height: 28px;
         }
-        .inner {
-            padding: 10px;
-            display: flex;
-            flex-direction: column;
-            max-width: 55%;
-            align-items: center;
-            text-align: center;
-            @include sm {
-                max-width: 45%;
-            }
-            h2 {
-                font-family: "space-grotesk-bold";
-                font-size: 16px;
-                line-height: 22px;
-                color: black;
-                padding: 10px 15px 5px 15px;
-                @include sm {
-                    padding: 10px 35px;
-                    font-size: 22px;
-                    line-height: 28px;
-                }
-            }
-            p {
-                font-family: "space-grotesk-light";
-                color: black;
-                font-size: 9px;
-                line-height: 14px;
-                @include md {
-                    font-size: 13px;
-                    line-height: 18px;
-                }
-            }
-            .access-btn {
-                color: #f7f7f7;
-                text-decoration: none;
-                padding: 1px 13px;
-                background-color: black;
-                position: relative;
-                display: block;
-                font-size: 8px;
-                border: none;
-                font-family: "space-grotesk-bold";
-                border-radius: 40px;
-                margin-top: 5px;
-                @include md {
-                    padding: 9px 25px;
-                    font-size: 12px;
-                    margin-top: 15px;
-                }
-            }
+      }
+      p {
+        font-family: 'space-grotesk-light';
+        color: black;
+        font-size: 9px;
+        line-height: 14px;
+        @include md {
+          font-size: 13px;
+          line-height: 18px;
         }
+      }
+      .access-btn {
+        color: #f7f7f7;
+        text-decoration: none;
+        padding: 1px 13px;
+        background-color: black;
+        position: relative;
+        display: block;
+        font-size: 8px;
+        border: none;
+        font-family: 'space-grotesk-bold';
+        border-radius: 40px;
+        margin-top: 5px;
+        @include md {
+          padding: 9px 25px;
+          font-size: 12px;
+          margin-top: 15px;
+        }
+      }
     }
+  }
 }
 
 .contributors {
-    max-width: 1200px;
-    margin: 5rem auto 5rem auto;
+  max-width: 1200px;
+  margin: 5rem auto 5rem auto;
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  .image-container {
+    display: inline-flex;
+    width: calc(33% - 35px);
     position: relative;
-    display: flex;
-    flex-wrap: wrap;
+    padding: 10px 15px;
     justify-content: center;
-    .image-container {
-        display: inline-flex;
-        width: calc(33% - 35px);
-        position: relative;
-        padding: 10px 15px;
-        justify-content: center;
-        @include md {
-            width: calc(20% - 30px);
-        }
-        .contributor-pic {
-            border-radius: 50%;
-            width: 100%;
-            height: auto;
-            padding: 10px 20px;
-        }
+    @include md {
+      width: calc(20% - 30px);
     }
+    .contributor-pic {
+      border-radius: 50%;
+      width: 100%;
+      height: auto;
+      padding: 10px 20px;
+    }
+  }
+}
+
+.fetch-status {
+  font-family: 'space-grotesk-bold';
+  margin: 5rem auto 5rem auto;
+  text-align: center;
+  font-size: 2rem;
+  color: #f7f7f7;
 }

--- a/src/contributors.njk
+++ b/src/contributors.njk
@@ -28,53 +28,155 @@ title: Contributors
     </div>
   </div>
 </section>
-<section class="contributors">
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
+<section aria-label="List of GitHub contributors">
+  <div class="fetch-status" id="contributors-fetch-status">
+    <span class="status-loading" id="contributors-status-loading">Loading Contributors… ⏳</span>
+    <span aria-live="polite" hidden class="status-error" id="contributors-status-error">Could not load GitHub Contributors 😔</span>
   </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
-  </div>
-  <div class='image-container'>
-    <img src="https://placehold.co/400" alt="Ross DiLiegro - Product Engineer" class="contributor-pic">
+  <div class="contributors" id="contributors" hidden>
+    {# Filled by script #}
   </div>
 </section>
+<script type="module">
+  // Unauthenticated REST endpoints are rate limited at usually 60req/IP/hour
+  // So we try to cache results in localStorage for an hour
+  const CACHE_RETENTION_MS = 1000 * 60 * 60;
+  const GITHUB_API_VERSION = "2022-11-28";
+  const LOCAL_STORAGE_CACHE_KEY = "contrib-cache";
+
+  function getCachedContributors() {
+    /*
+      Cache format v1
+
+      {
+        updated_at: number,
+        version: 1,
+        contributors: {
+          id: number,
+          login: string,
+          avatar_url: string,
+          html_url: string,
+          contributions: number,
+        }[]
+      }
+    */
+    const cachedUsers = JSON.parse(localStorage.getItem(LOCAL_STORAGE_CACHE_KEY));
+
+    if (!cachedUsers || cachedUsers.version !== 1) {
+      return null;
+    }
+
+    if (Date.now() - cachedUsers.updated_at > CACHE_RETENTION_MS) {
+      localStorage.removeItem(LOCAL_STORAGE_CACHE_KEY);
+      return null;
+    }
+
+    return cachedUsers.contributors;
+  }
+
+  function cacheContributors(contributors) {
+    const cacheData = JSON.stringify({
+      updated_at: Date.now(),
+      version: 1,
+      contributors,
+    });
+    localStorage.setItem(LOCAL_STORAGE_CACHE_KEY, cacheData);
+  }
+
+  async function fetchGithubJson(endpoint) {
+    const response = await fetch(`https://api.github.com${endpoint}`, {
+      headers: { "X-GitHub-Api-Version": GITHUB_API_VERSION }
+    });
+
+    if (!response.ok) {
+      throw new Error("Unknown error fetching from GitHub");
+    }
+
+    return await response.json();
+  }
+
+  async function fetchDevenContributors() {
+    const cached = getCachedContributors();
+
+    if (cached) {
+      return cached;
+    }
+
+    // Step 1: Fetch all public repos in deven-org
+    const orgRepos = await fetchGithubJson("/orgs/deven-org/repos");
+    // Step 2: Fetch all contributors for each repo
+    const contributorsResults = await Promise.allSettled(
+        orgRepos.map(repo => fetchGithubJson(`/repos/${repo.full_name}/contributors`))
+    );
+
+    // Using Promise.allSettled with this filter ignores partial fails
+    // i.e. if one repo cannot be fetched, we will ignore this
+    const contributorsLists = contributorsResults
+      .filter(res => res.status === "fulfilled" && res.value.length > 0)
+      .map(res => res.value);
+
+    const dedupedList = [];
+
+    for (const list of contributorsLists) {
+      for (const user of list) {
+        if (user.type !== "User") {
+          continue;
+        }
+
+        const existing = dedupedList.find(u => u.id === user.id);
+        if (existing) {
+          existing.contributions += user.contributions
+        } else {
+          const { id, login, avatar_url, html_url, contributions } = user;
+          dedupedList.push({ id, login, avatar_url, html_url, contributions });
+        }
+      }
+    }
+
+    if (dedupedList.length === 0) {
+      throw new Error("No contributors found");
+    }
+
+    dedupedList.sort((a, b) => b.contributions - a.contributions); // descending
+
+    cacheContributors(dedupedList);
+
+    return dedupedList;
+  }
+
+
+  fetchDevenContributors().then((contributors) => {
+    const contributorsSection = document.getElementById("contributors");
+
+    for (const user of contributors) {
+      /*
+        We're generating this:
+
+        <a href={user.html_url} class="image-container">
+          <img class="contributor-pic" src={user.avatar_url} alt={user.login} title={user.login} />
+        </a>
+      */
+
+      const userLink = document.createElement("a");
+      userLink.classList.add("image-container");
+      userLink.href = user.html_url;
+
+      const image = document.createElement("img");
+      image.src = user.avatar_url;
+      image.alt = user.login;
+      image.title = user.login;
+      image.classList.add("contributor-pic");
+
+      userLink.appendChild(image);
+      contributorsSection.appendChild(userLink);
+    }
+
+    document.getElementById("contributors-fetch-status").setAttribute("hidden", "");
+    contributorsSection.removeAttribute("hidden");
+  }).catch((e) => {
+    console.warn("An error occured while fetching the GitHub contributor list");
+    console.error(e);
+    document.getElementById("contributors-status-loading").setAttribute("hidden", "");
+    document.getElementById("contributors-status-error").removeAttribute("hidden");
+  });
+</script>


### PR DESCRIPTION
This solution is not perfect, it uses the unauthenticated REST API
Closes #133 

- It's the only publicly reachable API GitHub offers for this as far as I can see
- For any kind of authenticated access we would need to have an API secret of some kind which we shouldn't publish - then the request would have to happen as part of a backend instead of the user's browser. Which doesn't work with a generated static site

Unauthenticated access to the rest API is limited to roughly 60 requests per IP per hour from what I could find.

That's definitely enough for us (at the moment we have 6 requests) to fetch the contributors of all repos in the org, assuming the user hasn't used the API on some other page, or is sharing the IP with many other people. I added a simple hour-long cache using LocalStorage, so that we don't exceed the limit when reloading the page, but use the previously fetched results.

The per-IP limit could be an issue inside an Accenture VPN or WIFI.

Alternatives I see:
- Update contributors at build time and embed them statically. This might quickly get outdated and may be tricky to implement. Currently the builds happen on our development machines, where I'd prefer not to make network requests to GitHub for the build to be successful.
- Update contributors manually (Who will do that?)
- Find a public third-party API to embed contributors
  - Example for the OpenCollective one: https://remarkablemark.org/blog/2019/10/17/github-contributors-readme/ (only for repos on OpenCollective)
  - Note that these will likely not be org-based, but only for a single repo
  - Unless it's an actual API, we'll likely not have much control over the visuals

I think the implemented solution is the best I can think of for now, so I would go ahead with it, but please veto if you don't want it!

## Screenshots:
<img width="750" alt="A loading message saying: Loading Contributors… ⏳" src="https://github.com/deven-org/deven-website/assets/3317423/ced791c1-2c1e-4ebd-8bbc-966e163e40d3">
<img width="1834" alt="The successfully loaded Avatars" src="https://github.com/deven-org/deven-website/assets/3317423/3ef928eb-88cc-4b10-8505-077a806e5688">
<img width="1187" alt="An error message saying: Could not load GitHub Contributors 😔" src="https://github.com/deven-org/deven-website/assets/3317423/bb8da52f-3502-45d6-afa2-dc1a9c33eb73">

