### PR TITLE
feat: re-enable and refine post styling

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="/assets/css/contributors.css">
     <link rel="stylesheet" href="/assets/css/blog.css">
     <link rel="stylesheet" href="/assets/css/404.css">
+    <link rel="stylesheet" href="/assets/css/post.css">
     <link rel="stylesheet" href="/assets/css/prism-base16-monokai.dark.css">
     <link rel="alternate" href="/feed/feed.xml" type="application/atom+xml" title="DEVEN - Developer Enhancement">
   </head>

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="/assets/css/contributors.css">
     <link rel="stylesheet" href="/assets/css/blog.css">
     <link rel="stylesheet" href="/assets/css/404.css">
+    <link rel="stylesheet" href="/assets/css/post.css">
     <link rel="stylesheet" href="/assets/css/prism-base16-monokai.dark.css">
     <link rel="alternate" href="/feed/feed.xml" type="application/atom+xml" title="DEVEN - Developer Enhancement">
   </head>

--- a/docs/assets/css/post.css
+++ b/docs/assets/css/post.css
@@ -1,21 +1,24 @@
 .post-header {
-  margin: 150px 20px 80px 20px;
+  margin: 150px auto 80px auto;
+  padding-inline: 20px 50px;
   display: flex;
-  justify-content: space-around;
+  justify-content: flex-start;
+  column-gap: 150px;
+  max-width: min(90rem, 100vw);
   align-items: center;
   flex-direction: row;
 }
 .post-header .post-header-img {
   width: 600px;
-  height: 600px;
+  aspect-ratio: 1/1;
   border-radius: 30px;
   overflow: hidden;
   display: flex;
   justify-content: center;
 }
 .post-header .post-header-img img {
-  max-width: 100%;
-  height: 100%;
+  object-fit: cover;
+  width: 100%;
 }
 .post-header .post-header-autor {
   color: #f7f7f7;
@@ -32,9 +35,11 @@
 }
 @media screen and (min-width: 768px) and (max-width: 991px) {
   .post-header {
-    margin: 150px 20px 20px 20px;
+    margin-bottom: 20px;
+    padding-inline: 20px;
     justify-content: flex-start;
     flex-direction: row;
+    column-gap: 40px;
     justify-content: space-around;
     align-items: center;
   }
@@ -47,12 +52,12 @@
   }
   .post-header .post-header-img {
     width: 400px;
-    height: 400px;
   }
 }
 @media (max-width: 767px) {
   .post-header {
-    margin: 150px 20px 20px 20px;
+    margin-bottom: 20px;
+    padding-inline: 20px;
     justify-content: flex-start;
     flex-direction: column;
     align-items: normal;
@@ -66,12 +71,13 @@
   }
   .post-header .post-header-img {
     width: 100%;
-    height: 400px;
+    aspect-ratio: 3/2;
   }
 }
 
 .post-content-wrapper {
   margin: 0px auto;
+  max-width: 55rem;
   color: #fff;
 }
 @media screen and (min-width: 1200px) {

--- a/docs/blog-post/index.html
+++ b/docs/blog-post/index.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="/assets/css/contributors.css">
     <link rel="stylesheet" href="/assets/css/blog.css">
     <link rel="stylesheet" href="/assets/css/404.css">
+    <link rel="stylesheet" href="/assets/css/post.css">
     <link rel="stylesheet" href="/assets/css/prism-base16-monokai.dark.css">
     <link rel="alternate" href="/feed/feed.xml" type="application/atom+xml" title="DEVEN - Developer Enhancement">
   </head>

--- a/docs/boiler/index.html
+++ b/docs/boiler/index.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="/assets/css/contributors.css">
     <link rel="stylesheet" href="/assets/css/blog.css">
     <link rel="stylesheet" href="/assets/css/404.css">
+    <link rel="stylesheet" href="/assets/css/post.css">
     <link rel="stylesheet" href="/assets/css/prism-base16-monokai.dark.css">
     <link rel="alternate" href="/feed/feed.xml" type="application/atom+xml" title="DEVEN - Developer Enhancement">
   </head>

--- a/docs/contributors/index.html
+++ b/docs/contributors/index.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="/assets/css/contributors.css">
     <link rel="stylesheet" href="/assets/css/blog.css">
     <link rel="stylesheet" href="/assets/css/404.css">
+    <link rel="stylesheet" href="/assets/css/post.css">
     <link rel="stylesheet" href="/assets/css/prism-base16-monokai.dark.css">
     <link rel="alternate" href="/feed/feed.xml" type="application/atom+xml" title="DEVEN - Developer Enhancement">
   </head>

--- a/docs/documentation-skeleton/index.html
+++ b/docs/documentation-skeleton/index.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="/assets/css/contributors.css">
     <link rel="stylesheet" href="/assets/css/blog.css">
     <link rel="stylesheet" href="/assets/css/404.css">
+    <link rel="stylesheet" href="/assets/css/post.css">
     <link rel="stylesheet" href="/assets/css/prism-base16-monokai.dark.css">
     <link rel="alternate" href="/feed/feed.xml" type="application/atom+xml" title="DEVEN - Developer Enhancement">
   </head>

--- a/docs/feed/feed.xml
+++ b/docs/feed/feed.xml
@@ -18,7 +18,7 @@
 			<guid>https://thedeven.org/posts/20170110-what-is-web-compatibility/</guid>
 			<description type="html">&lt;p&gt;One week ago, I’ve started my job as Web Compatibility Engineer at Mozilla and it’s been wonderful so far!
 It’s a very welcoming place here in Berlin and my team is superb! So, summed up in one GIF?&lt;/p&gt;
-&lt;img class=&quot;post-item-image&quot; src=&quot;https://media.giphy.com/media/10uJ0IFxlCA06I/giphy.gif&quot; alt=&quot;Hands make a heart&quot; /&gt;
+&lt;img src=&quot;https://media.giphy.com/media/10uJ0IFxlCA06I/giphy.gif&quot; alt=&quot;Hands make a heart&quot; /&gt;
 &lt;p&gt;When people ask me, what I actually do, the conversations mostly go like this…&lt;/p&gt;
 &lt;p&gt;&lt;strong&gt;A: “So, Web Compatibility Engineer? Huh... What do you do exactly?”&lt;/strong&gt;&lt;br /&gt;
 B: “We make sure websites work in the same way on every platform.”&lt;br /&gt;
@@ -26,14 +26,14 @@ B: “We make sure websites work in the same way on every platform.”&lt;br /&g
 B: ”Yes, please! Just hop over to &lt;a href=&quot;https://webcompat.com/&quot;&gt;webcompat.com&lt;/a&gt; and let us know what you’ve found! We’ll help to fix it.”&lt;br /&gt;
 &lt;strong&gt;A: “Oh, great. So you can fix my broken website, right?”&lt;/strong&gt;&lt;br /&gt;
 B: “Well, it depends… Is your bug appearing in one browser, but not another? Then it is a webcompat bug and you should totally report it.”&lt;/p&gt;
-&lt;img class=&quot;post-item-image&quot; src=&quot;https://media.giphy.com/media/c4Nc0v0g15g9G/giphy.gif&quot; alt=&quot;Jake thinks this is interesting.&quot; /&gt;
+&lt;img src=&quot;https://media.giphy.com/media/c4Nc0v0g15g9G/giphy.gif&quot; alt=&quot;Jake thinks this is interesting.&quot; /&gt;
 &lt;h2 id=&quot;what-is-a-webcompat-bug%3F&quot; tabindex=&quot;-1&quot;&gt;What is a WebCompat bug? &lt;a class=&quot;bookmark&quot; href=&quot;https://thedeven.org/posts/20170110-what-is-web-compatibility/#what-is-a-webcompat-bug%3F&quot;&gt;#&lt;/a&gt;&lt;/h2&gt;
 &lt;p&gt;If you find a bug on a web site, just ask yourself… Is this happening just in one browser or in all of them?
 &lt;strong&gt;If it’s in more than three common browsers, please report the bug to the website youre browsing.&lt;/strong&gt; They’ll be happy about some good pointers how to reproduce the bug and which system / browser you are running etc, because everyone deserves good bug reports. ;)&lt;/p&gt;
 &lt;p&gt;&lt;strong&gt;If this is happening in just one or two browsers, this is pretty likely a WebCompat bug, which you should report over at &lt;a href=&quot;https://webcompat.com/&quot;&gt;webcompat.com&lt;/a&gt;.&lt;/strong&gt;
 This could be e.g. a prefix the website is using, but just for one browser and others are left out. Maybe the prefix isn’t even needed anymore. Or the specs are not implemented in a correct way into the browser. (Specs just say &lt;em&gt;what&lt;/em&gt; should be implemented, but not &lt;em&gt;how&lt;/em&gt;).&lt;/p&gt;
 &lt;p&gt;Your experience, knowledge and voice is what is the most important thing. Browser vendors need you! Your input. You are the ones building the web, shaping up the web.&lt;/p&gt;
-&lt;img class=&quot;post-item-image&quot; src=&quot;https://media.giphy.com/media/tnivTK2URZm7e/giphy.gif&quot; alt=&quot;Care bears sending hearts out of their bellies.&quot; /&gt;
+&lt;img src=&quot;https://media.giphy.com/media/tnivTK2URZm7e/giphy.gif&quot; alt=&quot;Care bears sending hearts out of their bellies.&quot; /&gt;
 &lt;p&gt;&lt;strong&gt;Thank you &amp;lt;3&lt;/strong&gt;&lt;/p&gt;
 &lt;p&gt;&lt;a href=&quot;https://zoepage.github.io/posts/20170116-why-do-we-need-web-compatibility/index.html&quot;&gt;Hop over to the second part!&lt;/a&gt;&lt;/p&gt;
 &lt;p&gt;&lt;small&gt;&lt;em&gt;This is the first part of a two part blog post.&lt;/em&gt;&lt;/small&gt;&lt;/p&gt;
@@ -49,18 +49,10 @@ This could be e.g. a prefix the website is using, but just for one browser and o
 &lt;h3 id=&quot;but-why-do-we-need-web-compatibility%3F&quot; tabindex=&quot;-1&quot;&gt;But why do we need Web Compatibility? &lt;a class=&quot;bookmark&quot; href=&quot;https://thedeven.org/posts/20170116-why-do-we-need-web-compatibility/#but-why-do-we-need-web-compatibility%3F&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
 &lt;p&gt;There are a so many things I&#39;ve heard from people why they do not report bugs.&lt;/p&gt;
 &lt;ul&gt;
-&lt;li&gt;
-&lt;p&gt;&amp;quot;I know this bug already.&amp;quot;&lt;/p&gt;
-&lt;/li&gt;
-&lt;li&gt;
-&lt;p&gt;&amp;quot;I can make this work in what... like 5 minutes.&amp;quot;&lt;/p&gt;
-&lt;/li&gt;
-&lt;li&gt;
-&lt;p&gt;&amp;quot;It&#39;s such an easy hack!&amp;quot;&lt;/p&gt;
-&lt;/li&gt;
-&lt;li&gt;
-&lt;p&gt;&amp;quot;Reporting that bug will take FOREVER!!!!&amp;quot;&lt;/p&gt;
-&lt;/li&gt;
+&lt;li&gt;&amp;quot;I know this bug already.&amp;quot;&lt;/li&gt;
+&lt;li&gt;&amp;quot;I can make this work in what... like 5 minutes.&amp;quot;&lt;/li&gt;
+&lt;li&gt;&amp;quot;It&#39;s such an easy hack!&amp;quot;&lt;/li&gt;
+&lt;li&gt;&amp;quot;Reporting that bug will take FOREVER!!!!&amp;quot;&lt;/li&gt;
 &lt;/ul&gt;
 &lt;br /&gt;
 &lt;p&gt;&lt;strong&gt;&amp;quot;To be accepted as a full standard, a spec must have two independent and interoperable implementations.&amp;quot;&lt;/strong&gt;&lt;/p&gt;
@@ -71,21 +63,21 @@ This could be e.g. a prefix the website is using, but just for one browser and o
 &lt;p&gt;&lt;a href=&quot;https://github.com/karlcow&quot;&gt;@karlcow&lt;/a&gt;&lt;/p&gt;
 &lt;h3 id=&quot;please%2C-stop...&quot; tabindex=&quot;-1&quot;&gt;Please, stop... &lt;a class=&quot;bookmark&quot; href=&quot;https://thedeven.org/posts/20170116-why-do-we-need-web-compatibility/#please%2C-stop...&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
 &lt;p&gt;We need to stop hacking things. Your voice matters to show browser vendors that we need interoperable specs, not different implementations. We as developers need tools that work from the get go in the right way.&lt;/p&gt;
-&lt;img class=&quot;post-item-image&quot; src=&quot;https://media.giphy.com/media/wpoLqr5FT1sY0/giphy.gif&quot; alt=&quot;Dog typing on keyboard.&quot; /&gt;
+&lt;img src=&quot;https://media.giphy.com/media/wpoLqr5FT1sY0/giphy.gif&quot; alt=&quot;Dog typing on keyboard.&quot; /&gt;
 &lt;p&gt;Clean code is valuable for everyone. Not just because updating hacked code is hard and you get yourself in a bigger mess everytime you do something. But also, because it takes us forever to find those browser quirks and learn things, we shouldn&#39;t need to know. Just think about how much time and frustration you had to go through, while you fought with those type of bugs?!&lt;/p&gt;
 &lt;p&gt;We should have a web that works for everyone. Make it not just user-, but developer-friendly.&lt;/p&gt;
 &lt;h3 id=&quot;benefits-of-reporting-%3C3&quot; tabindex=&quot;-1&quot;&gt;Benefits of reporting &amp;lt;3 &lt;a class=&quot;bookmark&quot; href=&quot;https://thedeven.org/posts/20170116-why-do-we-need-web-compatibility/#benefits-of-reporting-%3C3&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
 &lt;p&gt;You might assume the bug was already reported, because other developers do that all the time, right?
 Well... most likely? No. If you ask at a meetup, conference or where ever you meet other developers how many of them reported a bug before, 1-2 hands will go up. &lt;em&gt;If&lt;/em&gt; you&#39;re lucky!&lt;/p&gt;
 &lt;p&gt;And &lt;em&gt;what if&lt;/em&gt; it was &lt;em&gt;already&lt;/em&gt; reported? There is no dragon standing in front of the bug tracker and eat you alive, just because you dared to raise your voice and say a word about that bug...&lt;/p&gt;
-&lt;img class=&quot;post-item-image&quot; src=&quot;https://media.giphy.com/media/SIClNyzUQv5Vm/giphy.gif&quot; alt=&quot;Cute dragon scratching himself.&quot; /&gt;
+&lt;img src=&quot;https://media.giphy.com/media/SIClNyzUQv5Vm/giphy.gif&quot; alt=&quot;Cute dragon scratching himself.&quot; /&gt;
 &lt;p&gt;&lt;small&gt;(Okay, maybe just a very cute one, who is actually really nice and would love to give you a hug!)&lt;/small&gt;&lt;/p&gt;
 &lt;p&gt;The more developers report bugs, the higher is the chance to get all of them covered. PLUS it makes specific bugs so much more visible and the fact how annoyed developers are by &amp;quot;this specific one&amp;quot;, so browser vendors will prioritize it higher and fix it sooner.&lt;/p&gt;
 &lt;p&gt;Your experience, knowledge and voice is what is the most important thing. Browser vendors need you! Your input. You are the ones building the web, shaping up the web.&lt;/p&gt;
 &lt;h3 id=&quot;how-can-i-help-beyond-just-reporting-bugs%3F&quot; tabindex=&quot;-1&quot;&gt;How can I help beyond just reporting bugs? &lt;a class=&quot;bookmark&quot; href=&quot;https://thedeven.org/posts/20170116-why-do-we-need-web-compatibility/#how-can-i-help-beyond-just-reporting-bugs%3F&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
 &lt;p&gt;With reporting, you already did the biggest part on helping make the web accessible for everyone.
 But you can help also with checking out bugs, finding solutions or share your knowledge... You can find more about the how at &lt;a href=&quot;https://webcompat.com/contributors&quot;&gt;https://webcompat.com/contributors&lt;/a&gt;.&lt;/p&gt;
-&lt;img class=&quot;post-item-image&quot; src=&quot;https://media.giphy.com/media/tnivTK2URZm7e/giphy.gif&quot; alt=&quot;Care bears sending hearts out of their bellies.&quot; /&gt;
+&lt;img src=&quot;https://media.giphy.com/media/tnivTK2URZm7e/giphy.gif&quot; alt=&quot;Care bears sending hearts out of their bellies.&quot; /&gt;
 &lt;p&gt;&lt;strong&gt;Thank you &amp;lt;3&lt;/strong&gt;&lt;/p&gt;
 &lt;p&gt;&lt;small&gt;&lt;em&gt;This is the second part of a two part blog post.&lt;/em&gt;&lt;/small&gt;&lt;/p&gt;
 </description>
@@ -104,7 +96,7 @@ But you can help also with checking out bugs, finding solutions or share your kn
 &lt;li&gt;I am a solo mom of a 5 y/o.&lt;/li&gt;
 &lt;li&gt;I am a human being, with a need for breaks and social interactions.&lt;/li&gt;
 &lt;/ul&gt;
-&lt;img class=&quot;post-item-image&quot; src=&quot;https://media.giphy.com/media/JYkfr7F6d31hC/giphy-downsized.gif&quot; alt=&quot;Wait what?&quot; /&gt;
+&lt;img src=&quot;https://media.giphy.com/media/JYkfr7F6d31hC/giphy-downsized.gif&quot; alt=&quot;Wait what?&quot; /&gt;
 &lt;p&gt;All those things add up to enormous amount of tasks.&lt;/p&gt;
 &lt;p&gt;When I finish with a bug fix, three new issues appear and five people came up with questions already. Team meetings, refactors, new features.
 Laundry, grocery shopping, cooking, cleaning.
@@ -114,22 +106,22 @@ Keeping up with the little ones schedule and taking care of all her appointments
 &lt;p&gt;So, how do I deal with all of this without being burned out in a short amount of time? Well... it is not easy, but its somekind of doable. After three burnouts in my 20s (before I had a kid) I changed a lot how I handeled things.
 Following, I&#39;ll mention the things that helped me the most.&lt;/p&gt;
 &lt;h2 id=&quot;organize-%26%26-plan-ahead&quot; tabindex=&quot;-1&quot;&gt;Organize &amp;amp;&amp;amp; plan ahead &lt;a class=&quot;bookmark&quot; href=&quot;https://thedeven.org/posts/20170404-key-to-productivity/#organize-%26%26-plan-ahead&quot;&gt;#&lt;/a&gt;&lt;/h2&gt;
-&lt;img class=&quot;post-item-image&quot; src=&quot;https://media.giphy.com/media/xUOxf5B4tGwIh6WOw8/giphy-downsized.gif&quot; alt=&quot;Planner for 2017&quot; /&gt;
+&lt;img src=&quot;https://media.giphy.com/media/xUOxf5B4tGwIh6WOw8/giphy-downsized.gif&quot; alt=&quot;Planner for 2017&quot; /&gt;
 &lt;p&gt;Lists, notes and a calender can be a life saver. Start with the &amp;quot;bigger picture&amp;quot;. What lays ahead of you in the next 3 - 6 months? What do you need to do to make those things happen? Are there any deadlines you should be aware of? Make a plan, todo list and a schedule that&#39;ll help you navigate through the next few months.&lt;/p&gt;
 &lt;p&gt;The go on with the &amp;quot;smaller view&amp;quot;. Grab the next tasks or the ones that have the closest deadlines. If your time is short, don&#39;t be scared of downgrading tasks and putting them at the end of your list. They might become obsolete or you&#39;ll have time for it later or it becomes more pressuing and gets a bump up on your list. (This is also what makes you flexible.) Just make sure to work focused on one task after another.&lt;/p&gt;
 &lt;h2 id=&quot;stick-to-your-hours-%26%26-decisions&quot; tabindex=&quot;-1&quot;&gt;Stick to your hours &amp;amp;&amp;amp; decisions &lt;a class=&quot;bookmark&quot; href=&quot;https://thedeven.org/posts/20170404-key-to-productivity/#stick-to-your-hours-%26%26-decisions&quot;&gt;#&lt;/a&gt;&lt;/h2&gt;
-&lt;img class=&quot;post-item-image&quot; src=&quot;https://media.giphy.com/media/l0MYGtCMbPTYWOzaU/giphy-tumblr.gif&quot; alt=&quot;Sherlock lookig at his watch&quot; /&gt;
+&lt;img src=&quot;https://media.giphy.com/media/l0MYGtCMbPTYWOzaU/giphy-tumblr.gif&quot; alt=&quot;Sherlock lookig at his watch&quot; /&gt;
 &lt;p&gt;When you create a loose schedule it&#39;s all about balance. Make sure to add time for all important todos, but also for this thing called life... as life happens to all of us from time to time, right? Don&#39;t cut hours from your family time on a regular basis just because work comes up. Schedule more time in advance or leave it, but stick to your decisions.&lt;/p&gt;
 &lt;p&gt;Being really productive is not about working 24/7 or being available all the time. It’s about using your time right. Your are working? Work! Stop slacking on Youtube or Facebook. If you take a break like a chat with your colleagues allow it to yourself. Don&#39;t stress about it. But be aware of your time, the break and enjoy it.&lt;/p&gt;
 &lt;h2 id=&quot;let-it-go...&quot; tabindex=&quot;-1&quot;&gt;Let it go... &lt;a class=&quot;bookmark&quot; href=&quot;https://thedeven.org/posts/20170404-key-to-productivity/#let-it-go...&quot;&gt;#&lt;/a&gt;&lt;/h2&gt;
 &lt;p&gt;Enough is enough. Stop overthinging it. F*ck perfection. Ask for help. Stop blaming others or you. Just learn from it, find a solution and move on. Often you don&#39;t need to be the only person who works on the task. Document it and let it go if you have to.&lt;/p&gt;
 &lt;h2 id=&quot;know-your-limits!&quot; tabindex=&quot;-1&quot;&gt;Know your limits! &lt;a class=&quot;bookmark&quot; href=&quot;https://thedeven.org/posts/20170404-key-to-productivity/#know-your-limits!&quot;&gt;#&lt;/a&gt;&lt;/h2&gt;
-&lt;img class=&quot;post-item-image&quot; src=&quot;https://media.giphy.com/media/yxZlvexI0DyHI2Dyrf/giphy.gif&quot; alt=&quot;Power Puff Girl with circle eyes&quot; /&gt;
+&lt;img src=&quot;https://media.giphy.com/media/yxZlvexI0DyHI2Dyrf/giphy.gif&quot; alt=&quot;Power Puff Girl with circle eyes&quot; /&gt;
 &lt;p&gt;How much sleep do you need to feel creative, productive, good about yourself?
 How are you making sure you do hydrate yourself enough during the day? Did you eat something healthy? Or greasy because you need it right now? Which workout works for you or do you prefer to take a long bath? Hanging out with friends or enjoying alone time?&lt;/p&gt;
 &lt;p&gt;Be aware what recharges your batteries, physically AND emotionally. Don&#39;t compromise on that or even cut time down. You might increase your productivity for some time but its just for a short run.&lt;/p&gt;
 &lt;h2 id=&quot;learn-to-say-no&quot; tabindex=&quot;-1&quot;&gt;Learn to say NO &lt;a class=&quot;bookmark&quot; href=&quot;https://thedeven.org/posts/20170404-key-to-productivity/#learn-to-say-no&quot;&gt;#&lt;/a&gt;&lt;/h2&gt;
-&lt;img class=&quot;post-item-image&quot; src=&quot;https://media.giphy.com/media/EVbEdEW3kuu0o/giphy.gif&quot; alt=&quot;David Tennant as Doctor Who shakes his head.&quot; /&gt;
+&lt;img src=&quot;https://media.giphy.com/media/EVbEdEW3kuu0o/giphy.gif&quot; alt=&quot;David Tennant as Doctor Who shakes his head.&quot; /&gt;
 &lt;p&gt;Don&#39;t work on demand which means schedule fixed times for replying to messages like mails or direct messages. Review your notification settings. A thing I&#39;ve learned in the past few years is that there is no reply so important to drop whatever you do right now.&lt;/p&gt;
 &lt;p&gt;You don&#39;t need to save this world all by yourself. Learn to say no. Know who you can count on. Ask for help. Delegate requests to other people who might be intrested and have resources. But mostly important check in with yourself... Do you have the time, the energy or see any benefit for you before saying yes. This might sound selfish but as a close friend once told me &amp;quot;You have to take care of yourself, before you can take care of others.&amp;quot;... And he is right.&lt;/p&gt;
 &lt;p&gt;Schedule time for yourself or your family, friends. No mails during that time. No talking about work or thinking about issues to solve. You need a break from things as everyone else does. This is what keeps you productive and gives you a fresh point of view.&lt;/p&gt;

--- a/docs/imprint/index.html
+++ b/docs/imprint/index.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="/assets/css/contributors.css">
     <link rel="stylesheet" href="/assets/css/blog.css">
     <link rel="stylesheet" href="/assets/css/404.css">
+    <link rel="stylesheet" href="/assets/css/post.css">
     <link rel="stylesheet" href="/assets/css/prism-base16-monokai.dark.css">
     <link rel="alternate" href="/feed/feed.xml" type="application/atom+xml" title="DEVEN - Developer Enhancement">
   </head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="/assets/css/contributors.css">
     <link rel="stylesheet" href="/assets/css/blog.css">
     <link rel="stylesheet" href="/assets/css/404.css">
+    <link rel="stylesheet" href="/assets/css/post.css">
     <link rel="stylesheet" href="/assets/css/prism-base16-monokai.dark.css">
     <link rel="alternate" href="/feed/feed.xml" type="application/atom+xml" title="DEVEN - Developer Enhancement">
   </head>

--- a/docs/posts/20170110-what-is-web-compatibility/index.html
+++ b/docs/posts/20170110-what-is-web-compatibility/index.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="/assets/css/contributors.css">
     <link rel="stylesheet" href="/assets/css/blog.css">
     <link rel="stylesheet" href="/assets/css/404.css">
+    <link rel="stylesheet" href="/assets/css/post.css">
     <link rel="stylesheet" href="/assets/css/prism-base16-monokai.dark.css">
     <link rel="alternate" href="/feed/feed.xml" type="application/atom+xml" title="DEVEN - Developer Enhancement">
   </head>
@@ -80,7 +81,7 @@
 
 <div class="post-content-wrapper"> <p>One week ago, I’ve started my job as Web Compatibility Engineer at Mozilla and it’s been wonderful so far!
 It’s a very welcoming place here in Berlin and my team is superb! So, summed up in one GIF?</p>
-<img class="post-item-image" src="https://media.giphy.com/media/10uJ0IFxlCA06I/giphy.gif" alt="Hands make a heart" />
+<img src="https://media.giphy.com/media/10uJ0IFxlCA06I/giphy.gif" alt="Hands make a heart" />
 <p>When people ask me, what I actually do, the conversations mostly go like this…</p>
 <p><strong>A: “So, Web Compatibility Engineer? Huh... What do you do exactly?”</strong><br>
 B: “We make sure websites work in the same way on every platform.”<br>
@@ -88,14 +89,14 @@ B: “We make sure websites work in the same way on every platform.”<br>
 B: ”Yes, please! Just hop over to <a href="https://webcompat.com">webcompat.com</a> and let us know what you’ve found! We’ll help to fix it.”<br>
 <strong>A: “Oh, great. So you can fix my broken website, right?”</strong><br>
 B: “Well, it depends… Is your bug appearing in one browser, but not another? Then it is a webcompat bug and you should totally report it.”</p>
-<img class="post-item-image" src="https://media.giphy.com/media/c4Nc0v0g15g9G/giphy.gif" alt="Jake thinks this is interesting." />
+<img src="https://media.giphy.com/media/c4Nc0v0g15g9G/giphy.gif" alt="Jake thinks this is interesting." />
 <h2 id="what-is-a-webcompat-bug%3F" tabindex="-1">What is a WebCompat bug? <a class="bookmark" href="#what-is-a-webcompat-bug%3F">#</a></h2>
 <p>If you find a bug on a web site, just ask yourself… Is this happening just in one browser or in all of them?
 <strong>If it’s in more than three common browsers, please report the bug to the website youre browsing.</strong> They’ll be happy about some good pointers how to reproduce the bug and which system / browser you are running etc, because everyone deserves good bug reports. ;)</p>
 <p><strong>If this is happening in just one or two browsers, this is pretty likely a WebCompat bug, which you should report over at <a href="https://webcompat.com">webcompat.com</a>.</strong>
 This could be e.g. a prefix the website is using, but just for one browser and others are left out. Maybe the prefix isn’t even needed anymore. Or the specs are not implemented in a correct way into the browser. (Specs just say <em>what</em> should be implemented, but not <em>how</em>).</p>
 <p>Your experience, knowledge and voice is what is the most important thing. Browser vendors need you! Your input. You are the ones building the web, shaping up the web.</p>
-<img class="post-item-image" src="https://media.giphy.com/media/tnivTK2URZm7e/giphy.gif" alt="Care bears sending hearts out of their bellies." />
+<img src="https://media.giphy.com/media/tnivTK2URZm7e/giphy.gif" alt="Care bears sending hearts out of their bellies." />
 <p><strong>Thank you &lt;3</strong></p>
 <p><a href="https://zoepage.github.io/posts/20170116-why-do-we-need-web-compatibility/index.html">Hop over to the second part!</a></p>
 <p><small><em>This is the first part of a two part blog post.</em></small></p>

--- a/docs/posts/20170116-why-do-we-need-web-compatibility/index.html
+++ b/docs/posts/20170116-why-do-we-need-web-compatibility/index.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="/assets/css/contributors.css">
     <link rel="stylesheet" href="/assets/css/blog.css">
     <link rel="stylesheet" href="/assets/css/404.css">
+    <link rel="stylesheet" href="/assets/css/post.css">
     <link rel="stylesheet" href="/assets/css/prism-base16-monokai.dark.css">
     <link rel="alternate" href="/feed/feed.xml" type="application/atom+xml" title="DEVEN - Developer Enhancement">
   </head>
@@ -82,18 +83,10 @@
 <h3 id="but-why-do-we-need-web-compatibility%3F" tabindex="-1">But why do we need Web Compatibility? <a class="bookmark" href="#but-why-do-we-need-web-compatibility%3F">#</a></h3>
 <p>There are a so many things I've heard from people why they do not report bugs.</p>
 <ul>
-<li>
-<p>&quot;I know this bug already.&quot;</p>
-</li>
-<li>
-<p>&quot;I can make this work in what... like 5 minutes.&quot;</p>
-</li>
-<li>
-<p>&quot;It's such an easy hack!&quot;</p>
-</li>
-<li>
-<p>&quot;Reporting that bug will take FOREVER!!!!&quot;</p>
-</li>
+<li>&quot;I know this bug already.&quot;</li>
+<li>&quot;I can make this work in what... like 5 minutes.&quot;</li>
+<li>&quot;It's such an easy hack!&quot;</li>
+<li>&quot;Reporting that bug will take FOREVER!!!!&quot;</li>
 </ul>
 <br />
 <p><strong>&quot;To be accepted as a full standard, a spec must have two independent and interoperable implementations.&quot;</strong></p>
@@ -104,21 +97,21 @@
 <p><a href="https://github.com/karlcow">@karlcow</a></p>
 <h3 id="please%2C-stop..." tabindex="-1">Please, stop... <a class="bookmark" href="#please%2C-stop...">#</a></h3>
 <p>We need to stop hacking things. Your voice matters to show browser vendors that we need interoperable specs, not different implementations. We as developers need tools that work from the get go in the right way.</p>
-<img class="post-item-image" src="https://media.giphy.com/media/wpoLqr5FT1sY0/giphy.gif" alt="Dog typing on keyboard." />
+<img src="https://media.giphy.com/media/wpoLqr5FT1sY0/giphy.gif" alt="Dog typing on keyboard." />
 <p>Clean code is valuable for everyone. Not just because updating hacked code is hard and you get yourself in a bigger mess everytime you do something. But also, because it takes us forever to find those browser quirks and learn things, we shouldn't need to know. Just think about how much time and frustration you had to go through, while you fought with those type of bugs?!</p>
 <p>We should have a web that works for everyone. Make it not just user-, but developer-friendly.</p>
 <h3 id="benefits-of-reporting-%3C3" tabindex="-1">Benefits of reporting &lt;3 <a class="bookmark" href="#benefits-of-reporting-%3C3">#</a></h3>
 <p>You might assume the bug was already reported, because other developers do that all the time, right?
 Well... most likely? No. If you ask at a meetup, conference or where ever you meet other developers how many of them reported a bug before, 1-2 hands will go up. <em>If</em> you're lucky!</p>
 <p>And <em>what if</em> it was <em>already</em> reported? There is no dragon standing in front of the bug tracker and eat you alive, just because you dared to raise your voice and say a word about that bug...</p>
-<img class="post-item-image" src="https://media.giphy.com/media/SIClNyzUQv5Vm/giphy.gif" alt="Cute dragon scratching himself." />
+<img src="https://media.giphy.com/media/SIClNyzUQv5Vm/giphy.gif" alt="Cute dragon scratching himself." />
 <p><small>(Okay, maybe just a very cute one, who is actually really nice and would love to give you a hug!)</small></p>
 <p>The more developers report bugs, the higher is the chance to get all of them covered. PLUS it makes specific bugs so much more visible and the fact how annoyed developers are by &quot;this specific one&quot;, so browser vendors will prioritize it higher and fix it sooner.</p>
 <p>Your experience, knowledge and voice is what is the most important thing. Browser vendors need you! Your input. You are the ones building the web, shaping up the web.</p>
 <h3 id="how-can-i-help-beyond-just-reporting-bugs%3F" tabindex="-1">How can I help beyond just reporting bugs? <a class="bookmark" href="#how-can-i-help-beyond-just-reporting-bugs%3F">#</a></h3>
 <p>With reporting, you already did the biggest part on helping make the web accessible for everyone.
 But you can help also with checking out bugs, finding solutions or share your knowledge... You can find more about the how at <a href="https://webcompat.com/contributors">https://webcompat.com/contributors</a>.</p>
-<img class="post-item-image" src="https://media.giphy.com/media/tnivTK2URZm7e/giphy.gif" alt="Care bears sending hearts out of their bellies." />
+<img src="https://media.giphy.com/media/tnivTK2URZm7e/giphy.gif" alt="Care bears sending hearts out of their bellies." />
 <p><strong>Thank you &lt;3</strong></p>
 <p><small><em>This is the second part of a two part blog post.</em></small></p>
  </div>

--- a/docs/posts/20170404-key-to-productivity/index.html
+++ b/docs/posts/20170404-key-to-productivity/index.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="/assets/css/contributors.css">
     <link rel="stylesheet" href="/assets/css/blog.css">
     <link rel="stylesheet" href="/assets/css/404.css">
+    <link rel="stylesheet" href="/assets/css/post.css">
     <link rel="stylesheet" href="/assets/css/prism-base16-monokai.dark.css">
     <link rel="alternate" href="/feed/feed.xml" type="application/atom+xml" title="DEVEN - Developer Enhancement">
   </head>
@@ -86,7 +87,7 @@
 <li>I am a solo mom of a 5 y/o.</li>
 <li>I am a human being, with a need for breaks and social interactions.</li>
 </ul>
-<img class="post-item-image" src="https://media.giphy.com/media/JYkfr7F6d31hC/giphy-downsized.gif" alt="Wait what?" />
+<img src="https://media.giphy.com/media/JYkfr7F6d31hC/giphy-downsized.gif" alt="Wait what?" />
 <p>All those things add up to enormous amount of tasks.</p>
 <p>When I finish with a bug fix, three new issues appear and five people came up with questions already. Team meetings, refactors, new features.
 Laundry, grocery shopping, cooking, cleaning.
@@ -96,22 +97,22 @@ Keeping up with the little ones schedule and taking care of all her appointments
 <p>So, how do I deal with all of this without being burned out in a short amount of time? Well... it is not easy, but its somekind of doable. After three burnouts in my 20s (before I had a kid) I changed a lot how I handeled things.
 Following, I'll mention the things that helped me the most.</p>
 <h2 id="organize-%26%26-plan-ahead" tabindex="-1">Organize &amp;&amp; plan ahead <a class="bookmark" href="#organize-%26%26-plan-ahead">#</a></h2>
-<img class="post-item-image" src="https://media.giphy.com/media/xUOxf5B4tGwIh6WOw8/giphy-downsized.gif" alt="Planner for 2017" />
+<img src="https://media.giphy.com/media/xUOxf5B4tGwIh6WOw8/giphy-downsized.gif" alt="Planner for 2017" />
 <p>Lists, notes and a calender can be a life saver. Start with the &quot;bigger picture&quot;. What lays ahead of you in the next 3 - 6 months? What do you need to do to make those things happen? Are there any deadlines you should be aware of? Make a plan, todo list and a schedule that'll help you navigate through the next few months.</p>
 <p>The go on with the &quot;smaller view&quot;. Grab the next tasks or the ones that have the closest deadlines. If your time is short, don't be scared of downgrading tasks and putting them at the end of your list. They might become obsolete or you'll have time for it later or it becomes more pressuing and gets a bump up on your list. (This is also what makes you flexible.) Just make sure to work focused on one task after another.</p>
 <h2 id="stick-to-your-hours-%26%26-decisions" tabindex="-1">Stick to your hours &amp;&amp; decisions <a class="bookmark" href="#stick-to-your-hours-%26%26-decisions">#</a></h2>
-<img class="post-item-image" src="https://media.giphy.com/media/l0MYGtCMbPTYWOzaU/giphy-tumblr.gif" alt="Sherlock lookig at his watch" />
+<img src="https://media.giphy.com/media/l0MYGtCMbPTYWOzaU/giphy-tumblr.gif" alt="Sherlock lookig at his watch" />
 <p>When you create a loose schedule it's all about balance. Make sure to add time for all important todos, but also for this thing called life... as life happens to all of us from time to time, right? Don't cut hours from your family time on a regular basis just because work comes up. Schedule more time in advance or leave it, but stick to your decisions.</p>
 <p>Being really productive is not about working 24/7 or being available all the time. It’s about using your time right. Your are working? Work! Stop slacking on Youtube or Facebook. If you take a break like a chat with your colleagues allow it to yourself. Don't stress about it. But be aware of your time, the break and enjoy it.</p>
 <h2 id="let-it-go..." tabindex="-1">Let it go... <a class="bookmark" href="#let-it-go...">#</a></h2>
 <p>Enough is enough. Stop overthinging it. F*ck perfection. Ask for help. Stop blaming others or you. Just learn from it, find a solution and move on. Often you don't need to be the only person who works on the task. Document it and let it go if you have to.</p>
 <h2 id="know-your-limits!" tabindex="-1">Know your limits! <a class="bookmark" href="#know-your-limits!">#</a></h2>
-<img class="post-item-image" src="https://media.giphy.com/media/yxZlvexI0DyHI2Dyrf/giphy.gif" alt="Power Puff Girl with circle eyes" />
+<img src="https://media.giphy.com/media/yxZlvexI0DyHI2Dyrf/giphy.gif" alt="Power Puff Girl with circle eyes" />
 <p>How much sleep do you need to feel creative, productive, good about yourself?
 How are you making sure you do hydrate yourself enough during the day? Did you eat something healthy? Or greasy because you need it right now? Which workout works for you or do you prefer to take a long bath? Hanging out with friends or enjoying alone time?</p>
 <p>Be aware what recharges your batteries, physically AND emotionally. Don't compromise on that or even cut time down. You might increase your productivity for some time but its just for a short run.</p>
 <h2 id="learn-to-say-no" tabindex="-1">Learn to say NO <a class="bookmark" href="#learn-to-say-no">#</a></h2>
-<img class="post-item-image" src="https://media.giphy.com/media/EVbEdEW3kuu0o/giphy.gif" alt="David Tennant as Doctor Who shakes his head." />
+<img src="https://media.giphy.com/media/EVbEdEW3kuu0o/giphy.gif" alt="David Tennant as Doctor Who shakes his head." />
 <p>Don't work on demand which means schedule fixed times for replying to messages like mails or direct messages. Review your notification settings. A thing I've learned in the past few years is that there is no reply so important to drop whatever you do right now.</p>
 <p>You don't need to save this world all by yourself. Learn to say no. Know who you can count on. Ask for help. Delegate requests to other people who might be intrested and have resources. But mostly important check in with yourself... Do you have the time, the energy or see any benefit for you before saying yes. This might sound selfish but as a close friend once told me &quot;You have to take care of yourself, before you can take care of others.&quot;... And he is right.</p>
 <p>Schedule time for yourself or your family, friends. No mails during that time. No talking about work or thinking about issues to solve. You need a break from things as everyone else does. This is what keeps you productive and gives you a fresh point of view.</p>

--- a/docs/telemetry/index.html
+++ b/docs/telemetry/index.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="/assets/css/contributors.css">
     <link rel="stylesheet" href="/assets/css/blog.css">
     <link rel="stylesheet" href="/assets/css/404.css">
+    <link rel="stylesheet" href="/assets/css/post.css">
     <link rel="stylesheet" href="/assets/css/prism-base16-monokai.dark.css">
     <link rel="alternate" href="/feed/feed.xml" type="application/atom+xml" title="DEVEN - Developer Enhancement">
   </head>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -21,6 +21,7 @@
     <link rel="stylesheet" href="/assets/css/contributors.css">
     <link rel="stylesheet" href="/assets/css/blog.css">
     <link rel="stylesheet" href="/assets/css/404.css">
+    <link rel="stylesheet" href="/assets/css/post.css">
     <link rel="stylesheet" href="/assets/css/prism-base16-monokai.dark.css">
     <link rel="alternate" href="{{ metadata.feed.path }}" type="application/atom+xml" title="{{ metadata.title }}">
   </head>

--- a/src/assets/css/post.scss
+++ b/src/assets/css/post.scss
@@ -43,43 +43,48 @@ $screen-xl-min: 1200px;
 }
 
 .post-header {
-  margin: 150px 20px 80px 20px;
+  margin: 150px auto 80px auto;
+  padding-inline: 20px 50px;
   display: flex;
-  justify-content: space-around;
+  justify-content: flex-start;
+  column-gap: 150px;
+  max-width: min(90rem, 100vw);
   align-items: center;
   flex-direction: row;
 
   .post-header-img {
     width: 600px;
-    height: 600px;
+    aspect-ratio: 1/1;
     border-radius: 30px;
     overflow: hidden;
     display: flex;
     justify-content: center;
     img {
-      max-width: 100%;
-      height: 100%;
+      object-fit: cover;
+      width: 100%;
     }
   }
 
   .post-header-autor {
     color: #f7f7f7;
     font-size: 16px;
-    font-family: "space-grotesk-light";
+    font-family: 'space-grotesk-light';
   }
   .post-header-title {
     font-size: 40px;
     font-weight: 700;
     color: #f7f7f7;
-    font-family: "space-grotesk-bold";
+    font-family: 'space-grotesk-bold';
     margin: 35px 0px;
     line-height: 120%;
   }
 
   @include md {
-    margin: 150px 20px 20px 20px;
+    margin-bottom: 20px;
+    padding-inline: 20px;
     justify-content: flex-start;
     flex-direction: row;
+    column-gap: 40px;
     justify-content: space-around;
     align-items: center;
     .post-header-autor {
@@ -91,11 +96,11 @@ $screen-xl-min: 1200px;
     }
     .post-header-img {
       width: 400px;
-      height: 400px;
     }
   }
   @include sm {
-    margin: 150px 20px 20px 20px;
+    margin-bottom: 20px;
+    padding-inline: 20px;
     justify-content: flex-start;
     flex-direction: column;
     align-items: normal;
@@ -108,13 +113,15 @@ $screen-xl-min: 1200px;
     }
     .post-header-img {
       width: 100%;
-      height: 400px;
+      aspect-ratio: 3/2;
     }
   }
 }
 
 .post-content-wrapper {
   margin: 0px auto;
+  max-width: 55rem;
+
   color: #fff;
   @include xl {
     width: 55%;
@@ -141,7 +148,7 @@ $screen-xl-min: 1200px;
   p {
     font-size: 16px;
     color: #f7f7f7;
-    font-family: "space-grotesk-light";
+    font-family: 'space-grotesk-light';
     margin: 20px 0px;
   }
 
@@ -149,11 +156,11 @@ $screen-xl-min: 1200px;
     font-size: 28px;
     font-weight: 700;
     color: #f7f7f7;
-    font-family: "space-grotesk-bold";
+    font-family: 'space-grotesk-bold';
     margin: 30px 0px 30px 0px;
   }
   a {
-    font-family: "space-grotesk-bold";
+    font-family: 'space-grotesk-bold';
     color: #f7f7f7;
     text-decoration: none;
     font-size: 18px;
@@ -168,7 +175,7 @@ $screen-xl-min: 1200px;
   li {
     font-size: 16px;
     color: #f7f7f7;
-    font-family: "space-grotesk-light";
+    font-family: 'space-grotesk-light';
     list-style-type: circle;
     padding: 5px 0;
   }

--- a/src/posts/20170110-what-is-web-compatibility.md
+++ b/src/posts/20170110-what-is-web-compatibility.md
@@ -3,19 +3,13 @@ title: What is Web Compatibility
 description: What is web compabitility exactly
 date: 2017-01-16
 author: User 1
-tags:
-  - mozilla
-  - web
-  - webcompat
-  - open source
-  - standards
 layout: layouts/post.njk
 ---
 
 One week ago, I’ve started my job as Web Compatibility Engineer at Mozilla and it’s been wonderful so far!
 It’s a very welcoming place here in Berlin and my team is superb! So, summed up in one GIF?
 
-<img class="post-item-image" src="https://media.giphy.com/media/10uJ0IFxlCA06I/giphy.gif" alt="Hands make a heart" />
+<img src="https://media.giphy.com/media/10uJ0IFxlCA06I/giphy.gif" alt="Hands make a heart" />
 
 When people ask me, what I actually do, the conversations mostly go like this…
 
@@ -26,7 +20,7 @@ B: ”Yes, please! Just hop over to [webcompat.com](https://webcompat.com) and l
 **A: “Oh, great. So you can fix my broken website, right?”**  
 B: “Well, it depends… Is your bug appearing in one browser, but not another? Then it is a webcompat bug and you should totally report it.”
 
-<img class="post-item-image" src="https://media.giphy.com/media/c4Nc0v0g15g9G/giphy.gif" alt="Jake thinks this is interesting." />
+<img src="https://media.giphy.com/media/c4Nc0v0g15g9G/giphy.gif" alt="Jake thinks this is interesting." />
 
 ## What is a WebCompat bug?
 
@@ -38,7 +32,7 @@ This could be e.g. a prefix the website is using, but just for one browser and o
 
 Your experience, knowledge and voice is what is the most important thing. Browser vendors need you! Your input. You are the ones building the web, shaping up the web.
 
-<img class="post-item-image" src="https://media.giphy.com/media/tnivTK2URZm7e/giphy.gif" alt="Care bears sending hearts out of their bellies." />
+<img src="https://media.giphy.com/media/tnivTK2URZm7e/giphy.gif" alt="Care bears sending hearts out of their bellies." />
 
 **Thank you <3**
 

--- a/src/posts/20170116-why-do-we-need-web-compatibility.md
+++ b/src/posts/20170116-why-do-we-need-web-compatibility.md
@@ -3,12 +3,6 @@ title: Why do we need Web Compatibility
 description: Why do we need standards for a healthy web
 date: 2017-01-16
 author: User 2
-tags:
-  - mozilla
-  - web
-  - webcompat
-  - open source
-  - standards
 layout: layouts/post.njk
 ---
 
@@ -19,11 +13,8 @@ Last week, I published the first part of this blog post called [What is Web Comp
 There are a so many things I've heard from people why they do not report bugs.
 
 - "I know this bug already."
-
 - "I can make this work in what... like 5 minutes."
-
 - "It's such an easy hack!"
-
 - "Reporting that bug will take FOREVER!!!!"
 
 <br />
@@ -44,7 +35,7 @@ There are a so many things I've heard from people why they do not report bugs.
 
 We need to stop hacking things. Your voice matters to show browser vendors that we need interoperable specs, not different implementations. We as developers need tools that work from the get go in the right way.
 
-<img class="post-item-image" src="https://media.giphy.com/media/wpoLqr5FT1sY0/giphy.gif" alt="Dog typing on keyboard." />
+<img src="https://media.giphy.com/media/wpoLqr5FT1sY0/giphy.gif" alt="Dog typing on keyboard." />
 
 Clean code is valuable for everyone. Not just because updating hacked code is hard and you get yourself in a bigger mess everytime you do something. But also, because it takes us forever to find those browser quirks and learn things, we shouldn't need to know. Just think about how much time and frustration you had to go through, while you fought with those type of bugs?!
 
@@ -57,7 +48,7 @@ Well... most likely? No. If you ask at a meetup, conference or where ever you me
 
 And _what if_ it was _already_ reported? There is no dragon standing in front of the bug tracker and eat you alive, just because you dared to raise your voice and say a word about that bug...
 
-<img class="post-item-image" src="https://media.giphy.com/media/SIClNyzUQv5Vm/giphy.gif" alt="Cute dragon scratching himself." />
+<img src="https://media.giphy.com/media/SIClNyzUQv5Vm/giphy.gif" alt="Cute dragon scratching himself." />
 
 <small>(Okay, maybe just a very cute one, who is actually really nice and would love to give you a hug!)</small>
 
@@ -70,7 +61,7 @@ Your experience, knowledge and voice is what is the most important thing. Browse
 With reporting, you already did the biggest part on helping make the web accessible for everyone.
 But you can help also with checking out bugs, finding solutions or share your knowledge... You can find more about the how at [https://webcompat.com/contributors](https://webcompat.com/contributors).
 
-<img class="post-item-image" src="https://media.giphy.com/media/tnivTK2URZm7e/giphy.gif" alt="Care bears sending hearts out of their bellies." />
+<img src="https://media.giphy.com/media/tnivTK2URZm7e/giphy.gif" alt="Care bears sending hearts out of their bellies." />
 
 **Thank you <3**
 

--- a/src/posts/20170404-key-to-productivity.md
+++ b/src/posts/20170404-key-to-productivity.md
@@ -3,10 +3,6 @@ title: Key to Productivity
 description: How to survive a busy life
 date: 2017-04-04
 author: User 1
-tags:
-  - productivity
-  - family
-  - health
 layout: layouts/post.njk
 ---
 
@@ -18,7 +14,7 @@ One of the first things people learn about me, I have a pretty busy life.
 - I am a solo mom of a 5 y/o.
 - I am a human being, with a need for breaks and social interactions.
 
-<img class="post-item-image" src="https://media.giphy.com/media/JYkfr7F6d31hC/giphy-downsized.gif" alt="Wait what?" />
+<img src="https://media.giphy.com/media/JYkfr7F6d31hC/giphy-downsized.gif" alt="Wait what?" />
 
 All those things add up to enormous amount of tasks.
 
@@ -34,7 +30,7 @@ Following, I'll mention the things that helped me the most.
 
 ## Organize && plan ahead
 
-<img class="post-item-image" src="https://media.giphy.com/media/xUOxf5B4tGwIh6WOw8/giphy-downsized.gif" alt="Planner for 2017" />
+<img src="https://media.giphy.com/media/xUOxf5B4tGwIh6WOw8/giphy-downsized.gif" alt="Planner for 2017" />
 
 Lists, notes and a calender can be a life saver. Start with the "bigger picture". What lays ahead of you in the next 3 - 6 months? What do you need to do to make those things happen? Are there any deadlines you should be aware of? Make a plan, todo list and a schedule that'll help you navigate through the next few months.
 
@@ -42,7 +38,7 @@ The go on with the "smaller view". Grab the next tasks or the ones that have the
 
 ## Stick to your hours && decisions
 
-<img class="post-item-image" src="https://media.giphy.com/media/l0MYGtCMbPTYWOzaU/giphy-tumblr.gif" alt="Sherlock lookig at his watch" />
+<img src="https://media.giphy.com/media/l0MYGtCMbPTYWOzaU/giphy-tumblr.gif" alt="Sherlock lookig at his watch" />
 
 When you create a loose schedule it's all about balance. Make sure to add time for all important todos, but also for this thing called life... as life happens to all of us from time to time, right? Don't cut hours from your family time on a regular basis just because work comes up. Schedule more time in advance or leave it, but stick to your decisions.
 
@@ -54,7 +50,7 @@ Enough is enough. Stop overthinging it. F\*ck perfection. Ask for help. Stop bla
 
 ## Know your limits!
 
-<img class="post-item-image" src="https://media.giphy.com/media/yxZlvexI0DyHI2Dyrf/giphy.gif" alt="Power Puff Girl with circle eyes" />
+<img src="https://media.giphy.com/media/yxZlvexI0DyHI2Dyrf/giphy.gif" alt="Power Puff Girl with circle eyes" />
 
 How much sleep do you need to feel creative, productive, good about yourself?
 How are you making sure you do hydrate yourself enough during the day? Did you eat something healthy? Or greasy because you need it right now? Which workout works for you or do you prefer to take a long bath? Hanging out with friends or enjoying alone time?
@@ -63,7 +59,7 @@ Be aware what recharges your batteries, physically AND emotionally. Don't compro
 
 ## Learn to say NO
 
-<img class="post-item-image" src="https://media.giphy.com/media/EVbEdEW3kuu0o/giphy.gif" alt="David Tennant as Doctor Who shakes his head." />
+<img src="https://media.giphy.com/media/EVbEdEW3kuu0o/giphy.gif" alt="David Tennant as Doctor Who shakes his head." />
 
 Don't work on demand which means schedule fixed times for replying to messages like mails or direct messages. Review your notification settings. A thing I've learned in the past few years is that there is no reply so important to drop whatever you do right now.
 


### PR DESCRIPTION
Implements part of #77, but I don't think it's finished yet. (e.g. author avatars are missing)

The post.scss was renamed from blog.scss a while ago, but the new CSS file never got included on the page , this is fixed in here.
I did some changes to the post headers to better reflect the figma design, and to not blow out of proportions on very large screens.