### PR TITLE
fix: make feed validate as rss 2.0

### DIFF
--- a/docs/feed/feed.xml
+++ b/docs/feed/feed.xml
@@ -1,94 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0">
-<channel>
-	<title>DEVEN - Developer Enhancement</title>
-	<description>Developer for Developer to make your (work) life easier!</description>
-	<link href="https://thedeven.org/feed/feed.xml" rel="self"/>
-	<link href="https://thedeven.org/"/>
-	<pubDate>2017-04-04T00:00:00Z</pubDate>
-	<guid>https://thedeven.org/</guid>
-	<managingEditor>
-		<name>Ola Gasidlo-Brändel</name>
-	</managingEditor>
-		
-		<item>
-			<title>What is Web Compatibility</title>
-			<link href="https://thedeven.org/posts/20170110-what-is-web-compatibility/"/>
-			<pubDate>2017-01-16T00:00:00Z</pubDate>
-			<guid>https://thedeven.org/posts/20170110-what-is-web-compatibility/</guid>
-			<description type="html">&lt;p&gt;One week ago, I’ve started my job as Web Compatibility Engineer at Mozilla and it’s been wonderful so far!
-It’s a very welcoming place here in Berlin and my team is superb! So, summed up in one GIF?&lt;/p&gt;
-&lt;img src=&quot;https://media.giphy.com/media/10uJ0IFxlCA06I/giphy.gif&quot; alt=&quot;Hands make a heart&quot; /&gt;
-&lt;p&gt;When people ask me, what I actually do, the conversations mostly go like this…&lt;/p&gt;
-&lt;p&gt;&lt;strong&gt;A: “So, Web Compatibility Engineer? Huh... What do you do exactly?”&lt;/strong&gt;&lt;br /&gt;
-B: “We make sure websites work in the same way on every platform.”&lt;br /&gt;
-&lt;strong&gt;A: ”So, I can report a bug when I find one?”&lt;/strong&gt;&lt;br /&gt;
-B: ”Yes, please! Just hop over to &lt;a href=&quot;https://webcompat.com/&quot;&gt;webcompat.com&lt;/a&gt; and let us know what you’ve found! We’ll help to fix it.”&lt;br /&gt;
-&lt;strong&gt;A: “Oh, great. So you can fix my broken website, right?”&lt;/strong&gt;&lt;br /&gt;
-B: “Well, it depends… Is your bug appearing in one browser, but not another? Then it is a webcompat bug and you should totally report it.”&lt;/p&gt;
-&lt;img src=&quot;https://media.giphy.com/media/c4Nc0v0g15g9G/giphy.gif&quot; alt=&quot;Jake thinks this is interesting.&quot; /&gt;
-&lt;h2 id=&quot;what-is-a-webcompat-bug%3F&quot; tabindex=&quot;-1&quot;&gt;What is a WebCompat bug? &lt;a class=&quot;bookmark&quot; href=&quot;https://thedeven.org/posts/20170110-what-is-web-compatibility/#what-is-a-webcompat-bug%3F&quot;&gt;#&lt;/a&gt;&lt;/h2&gt;
-&lt;p&gt;If you find a bug on a web site, just ask yourself… Is this happening just in one browser or in all of them?
-&lt;strong&gt;If it’s in more than three common browsers, please report the bug to the website youre browsing.&lt;/strong&gt; They’ll be happy about some good pointers how to reproduce the bug and which system / browser you are running etc, because everyone deserves good bug reports. ;)&lt;/p&gt;
-&lt;p&gt;&lt;strong&gt;If this is happening in just one or two browsers, this is pretty likely a WebCompat bug, which you should report over at &lt;a href=&quot;https://webcompat.com/&quot;&gt;webcompat.com&lt;/a&gt;.&lt;/strong&gt;
-This could be e.g. a prefix the website is using, but just for one browser and others are left out. Maybe the prefix isn’t even needed anymore. Or the specs are not implemented in a correct way into the browser. (Specs just say &lt;em&gt;what&lt;/em&gt; should be implemented, but not &lt;em&gt;how&lt;/em&gt;).&lt;/p&gt;
-&lt;p&gt;Your experience, knowledge and voice is what is the most important thing. Browser vendors need you! Your input. You are the ones building the web, shaping up the web.&lt;/p&gt;
-&lt;img src=&quot;https://media.giphy.com/media/tnivTK2URZm7e/giphy.gif&quot; alt=&quot;Care bears sending hearts out of their bellies.&quot; /&gt;
-&lt;p&gt;&lt;strong&gt;Thank you &amp;lt;3&lt;/strong&gt;&lt;/p&gt;
-&lt;p&gt;&lt;a href=&quot;https://zoepage.github.io/posts/20170116-why-do-we-need-web-compatibility/index.html&quot;&gt;Hop over to the second part!&lt;/a&gt;&lt;/p&gt;
-&lt;p&gt;&lt;small&gt;&lt;em&gt;This is the first part of a two part blog post.&lt;/em&gt;&lt;/small&gt;&lt;/p&gt;
-</description>
-		</item>
-		
-		<item>
-			<title>Why do we need Web Compatibility</title>
-			<link href="https://thedeven.org/posts/20170116-why-do-we-need-web-compatibility/"/>
-			<pubDate>2017-01-16T00:00:00Z</pubDate>
-			<guid>https://thedeven.org/posts/20170116-why-do-we-need-web-compatibility/</guid>
-			<description type="html">&lt;p&gt;Last week, I published the first part of this blog post called &lt;a href=&quot;https://zoepage.github.io/posts/20170110-what-is-web-compatibility/index.html&quot;&gt;What is Web Compatibility&lt;/a&gt;? It explained what web compatibility is (Does it work in most browsers? Is the bug appearing in just this one?) and how you can report it.&lt;/p&gt;
-&lt;h3 id=&quot;but-why-do-we-need-web-compatibility%3F&quot; tabindex=&quot;-1&quot;&gt;But why do we need Web Compatibility? &lt;a class=&quot;bookmark&quot; href=&quot;https://thedeven.org/posts/20170116-why-do-we-need-web-compatibility/#but-why-do-we-need-web-compatibility%3F&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
-&lt;p&gt;There are a so many things I&#39;ve heard from people why they do not report bugs.&lt;/p&gt;
-&lt;ul&gt;
-&lt;li&gt;&amp;quot;I know this bug already.&amp;quot;&lt;/li&gt;
-&lt;li&gt;&amp;quot;I can make this work in what... like 5 minutes.&amp;quot;&lt;/li&gt;
-&lt;li&gt;&amp;quot;It&#39;s such an easy hack!&amp;quot;&lt;/li&gt;
-&lt;li&gt;&amp;quot;Reporting that bug will take FOREVER!!!!&amp;quot;&lt;/li&gt;
-&lt;/ul&gt;
-&lt;br /&gt;
-&lt;p&gt;&lt;strong&gt;&amp;quot;To be accepted as a full standard, a spec must have two independent and interoperable implementations.&amp;quot;&lt;/strong&gt;&lt;/p&gt;
-&lt;br /&gt;
-&lt;p&gt;&lt;em&gt;Web Compatibility is what we need when the Web interoperability process failed in some fashion. And here I&#39;m not talking only about standard organisations, but when different vendors failed to reach an agreement and it creates issues for the end users. Then you have to understand the issue and what is the best way to adjust the path. The power of a technological proposal is influenced a lot by the market shares of the vendor product.&lt;/em&gt;&lt;/p&gt;
-&lt;p&gt;&lt;em&gt; If a vendor implements a tool to be able to reload part of a document without making a HTTP request for the full document AND has a very large market share… you get XMLHttpRequest which was created by IE (initially as an activeX mechanism) and that other browsers were forced to implement (with its own twisted history). &lt;/em&gt;&lt;/p&gt;
-&lt;p&gt;&lt;em&gt; Web SQL and IndexedDB is a twisted history of Apple which had vested interests in another technology.&lt;/em&gt;&lt;/p&gt;
-&lt;p&gt;&lt;a href=&quot;https://github.com/karlcow&quot;&gt;@karlcow&lt;/a&gt;&lt;/p&gt;
-&lt;h3 id=&quot;please%2C-stop...&quot; tabindex=&quot;-1&quot;&gt;Please, stop... &lt;a class=&quot;bookmark&quot; href=&quot;https://thedeven.org/posts/20170116-why-do-we-need-web-compatibility/#please%2C-stop...&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
-&lt;p&gt;We need to stop hacking things. Your voice matters to show browser vendors that we need interoperable specs, not different implementations. We as developers need tools that work from the get go in the right way.&lt;/p&gt;
-&lt;img src=&quot;https://media.giphy.com/media/wpoLqr5FT1sY0/giphy.gif&quot; alt=&quot;Dog typing on keyboard.&quot; /&gt;
-&lt;p&gt;Clean code is valuable for everyone. Not just because updating hacked code is hard and you get yourself in a bigger mess everytime you do something. But also, because it takes us forever to find those browser quirks and learn things, we shouldn&#39;t need to know. Just think about how much time and frustration you had to go through, while you fought with those type of bugs?!&lt;/p&gt;
-&lt;p&gt;We should have a web that works for everyone. Make it not just user-, but developer-friendly.&lt;/p&gt;
-&lt;h3 id=&quot;benefits-of-reporting-%3C3&quot; tabindex=&quot;-1&quot;&gt;Benefits of reporting &amp;lt;3 &lt;a class=&quot;bookmark&quot; href=&quot;https://thedeven.org/posts/20170116-why-do-we-need-web-compatibility/#benefits-of-reporting-%3C3&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
-&lt;p&gt;You might assume the bug was already reported, because other developers do that all the time, right?
-Well... most likely? No. If you ask at a meetup, conference or where ever you meet other developers how many of them reported a bug before, 1-2 hands will go up. &lt;em&gt;If&lt;/em&gt; you&#39;re lucky!&lt;/p&gt;
-&lt;p&gt;And &lt;em&gt;what if&lt;/em&gt; it was &lt;em&gt;already&lt;/em&gt; reported? There is no dragon standing in front of the bug tracker and eat you alive, just because you dared to raise your voice and say a word about that bug...&lt;/p&gt;
-&lt;img src=&quot;https://media.giphy.com/media/SIClNyzUQv5Vm/giphy.gif&quot; alt=&quot;Cute dragon scratching himself.&quot; /&gt;
-&lt;p&gt;&lt;small&gt;(Okay, maybe just a very cute one, who is actually really nice and would love to give you a hug!)&lt;/small&gt;&lt;/p&gt;
-&lt;p&gt;The more developers report bugs, the higher is the chance to get all of them covered. PLUS it makes specific bugs so much more visible and the fact how annoyed developers are by &amp;quot;this specific one&amp;quot;, so browser vendors will prioritize it higher and fix it sooner.&lt;/p&gt;
-&lt;p&gt;Your experience, knowledge and voice is what is the most important thing. Browser vendors need you! Your input. You are the ones building the web, shaping up the web.&lt;/p&gt;
-&lt;h3 id=&quot;how-can-i-help-beyond-just-reporting-bugs%3F&quot; tabindex=&quot;-1&quot;&gt;How can I help beyond just reporting bugs? &lt;a class=&quot;bookmark&quot; href=&quot;https://thedeven.org/posts/20170116-why-do-we-need-web-compatibility/#how-can-i-help-beyond-just-reporting-bugs%3F&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
-&lt;p&gt;With reporting, you already did the biggest part on helping make the web accessible for everyone.
-But you can help also with checking out bugs, finding solutions or share your knowledge... You can find more about the how at &lt;a href=&quot;https://webcompat.com/contributors&quot;&gt;https://webcompat.com/contributors&lt;/a&gt;.&lt;/p&gt;
-&lt;img src=&quot;https://media.giphy.com/media/tnivTK2URZm7e/giphy.gif&quot; alt=&quot;Care bears sending hearts out of their bellies.&quot; /&gt;
-&lt;p&gt;&lt;strong&gt;Thank you &amp;lt;3&lt;/strong&gt;&lt;/p&gt;
-&lt;p&gt;&lt;small&gt;&lt;em&gt;This is the second part of a two part blog post.&lt;/em&gt;&lt;/small&gt;&lt;/p&gt;
-</description>
-		</item>
-		
-		<item>
-			<title>Key to Productivity</title>
-			<link href="https://thedeven.org/posts/20170404-key-to-productivity/"/>
-			<pubDate>2017-04-04T00:00:00Z</pubDate>
-			<guid>https://thedeven.org/posts/20170404-key-to-productivity/</guid>
-			<description type="html">&lt;p&gt;One of the first things people learn about me, I have a pretty busy life.&lt;/p&gt;
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xml:base="https://thedeven.org/" xmlns:atom="http://www.w3.org/2005/Atom">
+	<channel>
+		<title>DEVEN - Developer Enhancement</title>
+		<link>https://thedeven.org/</link>
+		<atom:link href="https://thedeven.org/feed/feed.xml" rel="self" type="application/rss+xml" />
+		<description>Developer for Developer to make your (work) life easier!</description>
+		<pubDate>Tue, 04 Apr 2017 02:00:00 +0000</pubDate>
+		<managingEditor>ogb@fastmail.com (Ola Gasidlo-Brändel)</managingEditor>
+			
+			<item>
+				<title>Key to Productivity</title>
+				<link>https://thedeven.org/posts/20170404-key-to-productivity/</link>
+				<description>&lt;p&gt;One of the first things people learn about me, I have a pretty busy life.&lt;/p&gt;
 &lt;ul&gt;
 &lt;li&gt;I am a engineer who works full-time on Firefox.&lt;/li&gt;
 &lt;li&gt;I speak frequently at conferences.&lt;/li&gt;
@@ -127,6 +50,83 @@ How are you making sure you do hydrate yourself enough during the day? Did you e
 &lt;p&gt;Schedule time for yourself or your family, friends. No mails during that time. No talking about work or thinking about issues to solve. You need a break from things as everyone else does. This is what keeps you productive and gives you a fresh point of view.&lt;/p&gt;
 &lt;p&gt;&lt;strong&gt;I feel like being aware of yourself, your life&#39;s requirements and challenges also your time and your always changing energy levels is... the key to productivity.&lt;/strong&gt;&lt;/p&gt;
 </description>
-		</item>
-</channel>
+				<pubDate>Tue, 04 Apr 2017 02:00:00 +0000</pubDate>
+				<dc:creator>User 1</dc:creator>
+				<guid>https://thedeven.org/posts/20170404-key-to-productivity/</guid>
+			</item>
+			
+			<item>
+				<title>Why do we need Web Compatibility</title>
+				<link>https://thedeven.org/posts/20170116-why-do-we-need-web-compatibility/</link>
+				<description>&lt;p&gt;Last week, I published the first part of this blog post called &lt;a href=&quot;https://zoepage.github.io/posts/20170110-what-is-web-compatibility/index.html&quot;&gt;What is Web Compatibility&lt;/a&gt;? It explained what web compatibility is (Does it work in most browsers? Is the bug appearing in just this one?) and how you can report it.&lt;/p&gt;
+&lt;h3 id=&quot;but-why-do-we-need-web-compatibility%3F&quot; tabindex=&quot;-1&quot;&gt;But why do we need Web Compatibility? &lt;a class=&quot;bookmark&quot; href=&quot;https://thedeven.org/posts/20170116-why-do-we-need-web-compatibility/#but-why-do-we-need-web-compatibility%3F&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
+&lt;p&gt;There are a so many things I&#39;ve heard from people why they do not report bugs.&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;&amp;quot;I know this bug already.&amp;quot;&lt;/li&gt;
+&lt;li&gt;&amp;quot;I can make this work in what... like 5 minutes.&amp;quot;&lt;/li&gt;
+&lt;li&gt;&amp;quot;It&#39;s such an easy hack!&amp;quot;&lt;/li&gt;
+&lt;li&gt;&amp;quot;Reporting that bug will take FOREVER!!!!&amp;quot;&lt;/li&gt;
+&lt;/ul&gt;
+&lt;br /&gt;
+&lt;p&gt;&lt;strong&gt;&amp;quot;To be accepted as a full standard, a spec must have two independent and interoperable implementations.&amp;quot;&lt;/strong&gt;&lt;/p&gt;
+&lt;br /&gt;
+&lt;p&gt;&lt;em&gt;Web Compatibility is what we need when the Web interoperability process failed in some fashion. And here I&#39;m not talking only about standard organisations, but when different vendors failed to reach an agreement and it creates issues for the end users. Then you have to understand the issue and what is the best way to adjust the path. The power of a technological proposal is influenced a lot by the market shares of the vendor product.&lt;/em&gt;&lt;/p&gt;
+&lt;p&gt;&lt;em&gt; If a vendor implements a tool to be able to reload part of a document without making a HTTP request for the full document AND has a very large market share… you get XMLHttpRequest which was created by IE (initially as an activeX mechanism) and that other browsers were forced to implement (with its own twisted history). &lt;/em&gt;&lt;/p&gt;
+&lt;p&gt;&lt;em&gt; Web SQL and IndexedDB is a twisted history of Apple which had vested interests in another technology.&lt;/em&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href=&quot;https://github.com/karlcow&quot;&gt;@karlcow&lt;/a&gt;&lt;/p&gt;
+&lt;h3 id=&quot;please%2C-stop...&quot; tabindex=&quot;-1&quot;&gt;Please, stop... &lt;a class=&quot;bookmark&quot; href=&quot;https://thedeven.org/posts/20170116-why-do-we-need-web-compatibility/#please%2C-stop...&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
+&lt;p&gt;We need to stop hacking things. Your voice matters to show browser vendors that we need interoperable specs, not different implementations. We as developers need tools that work from the get go in the right way.&lt;/p&gt;
+&lt;img src=&quot;https://media.giphy.com/media/wpoLqr5FT1sY0/giphy.gif&quot; alt=&quot;Dog typing on keyboard.&quot; /&gt;
+&lt;p&gt;Clean code is valuable for everyone. Not just because updating hacked code is hard and you get yourself in a bigger mess everytime you do something. But also, because it takes us forever to find those browser quirks and learn things, we shouldn&#39;t need to know. Just think about how much time and frustration you had to go through, while you fought with those type of bugs?!&lt;/p&gt;
+&lt;p&gt;We should have a web that works for everyone. Make it not just user-, but developer-friendly.&lt;/p&gt;
+&lt;h3 id=&quot;benefits-of-reporting-%3C3&quot; tabindex=&quot;-1&quot;&gt;Benefits of reporting &amp;lt;3 &lt;a class=&quot;bookmark&quot; href=&quot;https://thedeven.org/posts/20170116-why-do-we-need-web-compatibility/#benefits-of-reporting-%3C3&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
+&lt;p&gt;You might assume the bug was already reported, because other developers do that all the time, right?
+Well... most likely? No. If you ask at a meetup, conference or where ever you meet other developers how many of them reported a bug before, 1-2 hands will go up. &lt;em&gt;If&lt;/em&gt; you&#39;re lucky!&lt;/p&gt;
+&lt;p&gt;And &lt;em&gt;what if&lt;/em&gt; it was &lt;em&gt;already&lt;/em&gt; reported? There is no dragon standing in front of the bug tracker and eat you alive, just because you dared to raise your voice and say a word about that bug...&lt;/p&gt;
+&lt;img src=&quot;https://media.giphy.com/media/SIClNyzUQv5Vm/giphy.gif&quot; alt=&quot;Cute dragon scratching himself.&quot; /&gt;
+&lt;p&gt;&lt;small&gt;(Okay, maybe just a very cute one, who is actually really nice and would love to give you a hug!)&lt;/small&gt;&lt;/p&gt;
+&lt;p&gt;The more developers report bugs, the higher is the chance to get all of them covered. PLUS it makes specific bugs so much more visible and the fact how annoyed developers are by &amp;quot;this specific one&amp;quot;, so browser vendors will prioritize it higher and fix it sooner.&lt;/p&gt;
+&lt;p&gt;Your experience, knowledge and voice is what is the most important thing. Browser vendors need you! Your input. You are the ones building the web, shaping up the web.&lt;/p&gt;
+&lt;h3 id=&quot;how-can-i-help-beyond-just-reporting-bugs%3F&quot; tabindex=&quot;-1&quot;&gt;How can I help beyond just reporting bugs? &lt;a class=&quot;bookmark&quot; href=&quot;https://thedeven.org/posts/20170116-why-do-we-need-web-compatibility/#how-can-i-help-beyond-just-reporting-bugs%3F&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
+&lt;p&gt;With reporting, you already did the biggest part on helping make the web accessible for everyone.
+But you can help also with checking out bugs, finding solutions or share your knowledge... You can find more about the how at &lt;a href=&quot;https://webcompat.com/contributors&quot;&gt;https://webcompat.com/contributors&lt;/a&gt;.&lt;/p&gt;
+&lt;img src=&quot;https://media.giphy.com/media/tnivTK2URZm7e/giphy.gif&quot; alt=&quot;Care bears sending hearts out of their bellies.&quot; /&gt;
+&lt;p&gt;&lt;strong&gt;Thank you &amp;lt;3&lt;/strong&gt;&lt;/p&gt;
+&lt;p&gt;&lt;small&gt;&lt;em&gt;This is the second part of a two part blog post.&lt;/em&gt;&lt;/small&gt;&lt;/p&gt;
+</description>
+				<pubDate>Mon, 16 Jan 2017 01:00:00 +0000</pubDate>
+				<dc:creator>User 2</dc:creator>
+				<guid>https://thedeven.org/posts/20170116-why-do-we-need-web-compatibility/</guid>
+			</item>
+			
+			<item>
+				<title>What is Web Compatibility</title>
+				<link>https://thedeven.org/posts/20170110-what-is-web-compatibility/</link>
+				<description>&lt;p&gt;One week ago, I’ve started my job as Web Compatibility Engineer at Mozilla and it’s been wonderful so far!
+It’s a very welcoming place here in Berlin and my team is superb! So, summed up in one GIF?&lt;/p&gt;
+&lt;img src=&quot;https://media.giphy.com/media/10uJ0IFxlCA06I/giphy.gif&quot; alt=&quot;Hands make a heart&quot; /&gt;
+&lt;p&gt;When people ask me, what I actually do, the conversations mostly go like this…&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;A: “So, Web Compatibility Engineer? Huh... What do you do exactly?”&lt;/strong&gt;&lt;br /&gt;
+B: “We make sure websites work in the same way on every platform.”&lt;br /&gt;
+&lt;strong&gt;A: ”So, I can report a bug when I find one?”&lt;/strong&gt;&lt;br /&gt;
+B: ”Yes, please! Just hop over to &lt;a href=&quot;https://webcompat.com/&quot;&gt;webcompat.com&lt;/a&gt; and let us know what you’ve found! We’ll help to fix it.”&lt;br /&gt;
+&lt;strong&gt;A: “Oh, great. So you can fix my broken website, right?”&lt;/strong&gt;&lt;br /&gt;
+B: “Well, it depends… Is your bug appearing in one browser, but not another? Then it is a webcompat bug and you should totally report it.”&lt;/p&gt;
+&lt;img src=&quot;https://media.giphy.com/media/c4Nc0v0g15g9G/giphy.gif&quot; alt=&quot;Jake thinks this is interesting.&quot; /&gt;
+&lt;h2 id=&quot;what-is-a-webcompat-bug%3F&quot; tabindex=&quot;-1&quot;&gt;What is a WebCompat bug? &lt;a class=&quot;bookmark&quot; href=&quot;https://thedeven.org/posts/20170110-what-is-web-compatibility/#what-is-a-webcompat-bug%3F&quot;&gt;#&lt;/a&gt;&lt;/h2&gt;
+&lt;p&gt;If you find a bug on a web site, just ask yourself… Is this happening just in one browser or in all of them?
+&lt;strong&gt;If it’s in more than three common browsers, please report the bug to the website youre browsing.&lt;/strong&gt; They’ll be happy about some good pointers how to reproduce the bug and which system / browser you are running etc, because everyone deserves good bug reports. ;)&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;If this is happening in just one or two browsers, this is pretty likely a WebCompat bug, which you should report over at &lt;a href=&quot;https://webcompat.com/&quot;&gt;webcompat.com&lt;/a&gt;.&lt;/strong&gt;
+This could be e.g. a prefix the website is using, but just for one browser and others are left out. Maybe the prefix isn’t even needed anymore. Or the specs are not implemented in a correct way into the browser. (Specs just say &lt;em&gt;what&lt;/em&gt; should be implemented, but not &lt;em&gt;how&lt;/em&gt;).&lt;/p&gt;
+&lt;p&gt;Your experience, knowledge and voice is what is the most important thing. Browser vendors need you! Your input. You are the ones building the web, shaping up the web.&lt;/p&gt;
+&lt;img src=&quot;https://media.giphy.com/media/tnivTK2URZm7e/giphy.gif&quot; alt=&quot;Care bears sending hearts out of their bellies.&quot; /&gt;
+&lt;p&gt;&lt;strong&gt;Thank you &amp;lt;3&lt;/strong&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href=&quot;https://zoepage.github.io/posts/20170116-why-do-we-need-web-compatibility/index.html&quot;&gt;Hop over to the second part!&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;&lt;small&gt;&lt;em&gt;This is the first part of a two part blog post.&lt;/em&gt;&lt;/small&gt;&lt;/p&gt;
+</description>
+				<pubDate>Mon, 16 Jan 2017 01:00:00 +0000</pubDate>
+				<dc:creator>User 1</dc:creator>
+				<guid>https://thedeven.org/posts/20170110-what-is-web-compatibility/</guid>
+			</item>
+	</channel>
 </rss>

--- a/src/feed/feed.njk
+++ b/src/feed/feed.njk
@@ -4,26 +4,24 @@ excludeFromSitemap: true
 eleventyExcludeFromCollections: true
 ---
 <?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0">
-<channel>
-	<title>{{ metadata.title }}</title>
-	<description>{{ metadata.feed.subtitle }}</description>
-	<link href="{{ metadata.feed.url }}" rel="self"/>
-	<link href="{{ metadata.url }}"/>
-	<pubDate>{{ collections.posts | rssLastUpdatedDate }}</pubDate>
-	<guid>{{ metadata.feed.id }}</guid>
-	<managingEditor>
-		<name>{{ metadata.author.name }}</name>
-	</managingEditor>
-	{%- for post in collections.posts %}
-		{% set absolutePostUrl %}{{ post.url | url | absoluteUrl(metadata.url) }}{% endset %}
-		<item>
-			<title>{{ post.data.title }}</title>
-			<link href="{{ absolutePostUrl }}"/>
-			<pubDate>{{ post.date | rssDate }}</pubDate>
-			<guid>{{ absolutePostUrl }}</guid>
-			<description type="html">{{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}</description>
-		</item>
-	{%- endfor %}
-</channel>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xml:base="{{ metadata.url }}" xmlns:atom="http://www.w3.org/2005/Atom">
+	<channel>
+		<title>{{ metadata.title }}</title>
+		<link>{{ metadata.url }}</link>
+		<atom:link href="{{ permalink | absoluteUrl(metadata.url) }}" rel="self" type="application/rss+xml" />
+		<description>{{ metadata.feed.subtitle }}</description>
+		<pubDate>{{ collections.posts | getNewestCollectionItemDate | dateToRfc822 }}</pubDate>
+		<managingEditor>{{metadata.author.email}} ({{metadata.author.name}})</managingEditor>
+		{%- for post in collections.posts | reverse %}
+			{% set absolutePostUrl %}{{ post.url | absoluteUrl(metadata.url) }}{% endset %}
+			<item>
+				<title>{{ post.data.title }}</title>
+				<link>{{ absolutePostUrl }}</link>
+				<description>{{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}</description>
+				<pubDate>{{ post.date | dateToRfc822 }}</pubDate>
+				<dc:creator>{{ post.data.author or metadata.author.name }}</dc:creator>
+				<guid>{{ absolutePostUrl }}</guid>
+			</item>
+		{%- endfor %}
+	</channel>
 </rss>


### PR DESCRIPTION
closes #144 

The big diff mostly stems from me sorting the articles in reverse order (newest first)

The output validates using the [W3C Validator](https://validator.w3.org/feed/)
(There is one leftover warning about the `atom:link` element not referring to the feed's actual url, but I'm convinced that's gonna solve itself once the feed is published on the correct url, i.e. once we merge the changes)

I mostly aligned things with [the eleventy example](https://www.11ty.dev/docs/plugins/rss/) and looked a bit into the [RSS 2 spec + best practices](https://www.rssboard.org/rss-profile) where I was unsure 