### PR TITLE
fix: solve information exposure report

### DIFF
--- a/docs/contributors/index.html
+++ b/docs/contributors/index.html
@@ -99,7 +99,7 @@
   <div class="star">
     <div class="inner">
       <h2>How to join DEVEN org on GitHub?</h2>
-      <p>If you're an Accenture employee with an @accenture.com email address, you're in luck! You can join our organization to get all the details on what we're currently working on, ways to get involved, and other cool stuff. We have contribution guidelines and other resources waiting for you. Let's link up and see you on the other side!</p>
+      <p>If you're an Accenture employee with an Accenture email address, you're in luck! You can join our organization to get all the details on what we're currently working on, ways to get involved, and other cool stuff. We have contribution guidelines and other resources waiting for you. Let's link up and see you on the other side!</p>
       <a href='https://github.com/deven-org' target="_blank" class="access-btn">Request access →</a>
     </div>
   </div>

--- a/docs/imprint/index.html
+++ b/docs/imprint/index.html
@@ -78,7 +78,7 @@
     </p>
     <p>
       <span><strong>Email address:</strong> </span>
-      <span>ola.gasidlo-braendel@accenture.com</span>
+      <span>ola@opentechschool.org</span>
     </p>
     <p>
       <span><strong>Telephone number:</strong> </span>

--- a/src/_data/metadata.json
+++ b/src/_data/metadata.json
@@ -15,7 +15,7 @@
   },
   "imprint": {
     "name": "Ola Gasidlo-Braendel",
-    "email": "ola.gasidlo-braendel@accenture.com",
+    "email": "ola@opentechschool.org",
     "phone": "+49 (0) 151 2041801"
   }
 }

--- a/src/contributors.njk
+++ b/src/contributors.njk
@@ -28,7 +28,7 @@ headerBackground: offwhite
   <div class="star">
     <div class="inner">
       <h2>How to join DEVEN org on GitHub?</h2>
-      <p>If you're an Accenture employee with an @accenture.com email address, you're in luck! You can join our organization to get all the details on what we're currently working on, ways to get involved, and other cool stuff. We have contribution guidelines and other resources waiting for you. Let's link up and see you on the other side!</p>
+      <p>If you're an Accenture employee with an Accenture email address, you're in luck! You can join our organization to get all the details on what we're currently working on, ways to get involved, and other cool stuff. We have contribution guidelines and other resources waiting for you. Let's link up and see you on the other side!</p>
       <a href='https://github.com/deven-org' target="_blank" class="access-btn">Request access →</a>
     </div>
   </div>


### PR DESCRIPTION
Due to an automated internal report we need to remove the Accenture e-mail addresses from the content of the site