### PR TITLE
fix: allow crossorigin preloads of fonts

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -14,8 +14,8 @@
     <link rel="icon" href="/assets/favicon/favicon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/assets/favicon/apple-touch-icon.png">
     <meta name="Description" content="{{ renderData.description or description or metadata.description }}">
-    <link rel="preload" as="font" href="/assets/fonts/Hey November.woff2" type="font/woff2">
-    <link rel="preload" as="font" href="/assets/fonts/SpaceGrotesk.woff2" type="font/woff2">
+    <link rel="preload" as="font" href="/assets/fonts/Hey November.woff2" type="font/woff2" crossorigin="anonymous">
+    <link rel="preload" as="font" href="/assets/fonts/SpaceGrotesk.woff2" type="font/woff2" crossorigin="anonymous">
     <link rel="stylesheet" href="/assets/css/reset.css">
     <link rel="stylesheet" href="/assets/css/main.css">
     <link rel="stylesheet" href="/assets/css/home.css">


### PR DESCRIPTION
Chrome and sometimes Firefox warn in the console that our font preload does not work due to some crossorigin rule.

```
A preload for 'https://thedeven.org/assets/fonts/SpaceGrotesk.woff2' is found, but is not used because the request credentials mode does not match. Consider taking a look at crossorigin attribute.
```

I'm not entirely sure what is mismatching there, but setting `crossorigin=anonymous` on the links is supposed to be the fix mentioned everywhere when searching for it, and I don't see an issue with doing so.