### PR TITLE
fix: spacing between elements in current team content

### DIFF
--- a/docs/assets/css/home.css
+++ b/docs/assets/css/home.css
@@ -591,6 +591,7 @@ header h1.deven-headtext {
   flex-direction: column;
   align-items: center;
   gap: 60px;
+  --avatar-size: 170px;
 }
 @media (min-width: 768px) {
   .home > section.current-team {
@@ -621,8 +622,11 @@ header h1.deven-headtext {
 .home > section.current-team ul li img {
   border-radius: 50%;
   object-fit: cover;
-  width: 170px;
-  height: 170px;
+  width: var(--avatar-size);
+  height: var(--avatar-size);
+}
+.home > section.current-team ul li p {
+  max-width: var(--avatar-size);
 }
 .home > section.current-team ul li h3 {
   font-weight: bold;

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -81,13 +81,6 @@
     
       
           <url>
-              <loc>/</loc>
-              <lastmod>2024-01-30T10:24:50.004Z</lastmod>
-          </url>
-        
-    
-      
-          <url>
               <loc>/telemetry/</loc>
               <lastmod>2024-01-30T10:24:50.005Z</lastmod>
           </url>
@@ -97,6 +90,13 @@
           <url>
               <loc>/hamster/</loc>
               <lastmod>2024-01-30T12:40:19.422Z</lastmod>
+          </url>
+        
+    
+      
+          <url>
+              <loc>/</loc>
+              <lastmod>2024-01-30T12:57:18.680Z</lastmod>
           </url>
         
     

--- a/src/assets/css/home.scss
+++ b/src/assets/css/home.scss
@@ -660,6 +660,7 @@ header h1.deven-headtext {
   flex-direction: column;
   align-items: center;
   gap: 60px;
+  --avatar-size: 170px;
 
   @include media.md {
     gap: 120px;
@@ -689,8 +690,12 @@ header h1.deven-headtext {
       img {
         border-radius: 50%;
         object-fit: cover;
-        width: 170px;
-        height: 170px;
+        width: var(--avatar-size);
+        height: var(--avatar-size);
+      }
+
+      p {
+        max-width: var(--avatar-size);
       }
 
       h3 {


### PR DESCRIPTION
fix spacing between elements in current team content by giving the role the same width as the avatar